### PR TITLE
fix/$npm-bin-on-windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "publish": "lerna publish",
-    "bootstrap": "$(npm bin)/gulp clean && lerna bootstrap && gulp prepare",
+    "bootstrap": "./node_modules/.bin/gulp clean && lerna bootstrap && gulp prepare",
     "storybook": "npm -C ./storybook/storybook run storybook",
     "storybook:build": "npm -C ./storybook/storybook run storybook:build",
     "start": "npm -C ./examples/demo run start",

--- a/storybook/styles/package.json
+++ b/storybook/styles/package.json
@@ -7,7 +7,7 @@
     "dist/"
   ],
   "scripts": {
-    "prepare": "$(npm bin)/gulp buildstyle",
+    "prepare": "./node_modules/.bin/gulp buildstyle",
     "css": "webpack-dev-server --config src/demo/webpack.config.js",
     "css:build": "webpack --config src/demo/webpack.config.js",
     "lint:js": "eslint ./src/demo",


### PR DESCRIPTION
Issue
When run the stylebuild , the $(npm bin) doesn't work on Windows
Change it to './node_modules/.bin'

