### PR TITLE
fix(storybook): display name for Component Name

### DIFF
--- a/packages/Layout/header/src/Name/Name.js
+++ b/packages/Layout/header/src/Name/Name.js
@@ -53,5 +53,6 @@ class Name extends React.Component {
 
 Name.propTypes = propTypes;
 Name.defaultProps = defaultProps;
+Name.displayName = "Name";
 
 export default Name;


### PR DESCRIPTION
## Related issue
https://github.com/AxaGuilDEv/react-toolkit/issues/40

### Reference to the issue

https://github.com/AxaGuilDEv/react-toolkit/issues/40

### Description of the issue

Fix display name for Name component

### Person(s) for reviewing proposed changes

@guillaumechervetaxa @samuel-gomez-axa 

# Important

Before creating a pull request run unit tests

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```
