### PR TITLE
fix(popover): not working with onclick mode

### DIFF
--- a/packages/popover/src/Popover.js
+++ b/packages/popover/src/Popover.js
@@ -54,8 +54,8 @@ class PopoverClick extends Component {
       placement,
       className,
       classModifier,
-      isOpen,
     } = this.props;
+    const { isOpen } = this.state;
     return (
       <PopoverBase
         className={className}


### PR DESCRIPTION
## Related issue
https://github.com/AxaGuilDEv/react-toolkit/issues/193

### Description of the issue
Popover not working with onclick mode (nothing appens)

### Person(s) for reviewing proposed changes
@guillaumechervet 
@samuel-gomez-axa 
@barry-thierno 