### PR TITLE
refactor(restitution) Change titleLeft to rightTitle prop in HeaderRestitution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2830,13 +2830,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -10792,7 +10794,8 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10912,7 +10915,8 @@
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/restitution/src/HeaderRestitution.tsx
+++ b/packages/restitution/src/HeaderRestitution.tsx
@@ -12,10 +12,10 @@ type HeaderRestitutionBaseProps = {
   className?: string;
   title:React.ReactNode;
   subtitle?:React.ReactNode;
-  titleLeft?:React.ReactNode;
+  rightTitle?:React.ReactNode;
 }
 
-const HeaderRestitution = ({ title, subtitle, titleLeft, className }: HeaderRestitutionBaseProps) => (
+const HeaderRestitution = ({ title, subtitle, rightTitle, className }: HeaderRestitutionBaseProps) => (
     <header className={className}>
       <div className="af-restitution__header-left">
         <div className="af-restitution__title">
@@ -23,9 +23,9 @@ const HeaderRestitution = ({ title, subtitle, titleLeft, className }: HeaderRest
           <span className="af-restitution__title-subtitle">{subtitle}</span>
         </div>
       </div>
-      {titleLeft && (<div className="af-restitution__header-right">
+      {rightTitle && (<div className="af-restitution__header-right">
         <span className="af-restitution__title">
-          {titleLeft}
+          {rightTitle}
         </span>
       </div>)}
     </header>

--- a/packages/restitution/src/Restitution.spec.tsx
+++ b/packages/restitution/src/Restitution.spec.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { ArticleRestitution, HeaderRestitution, SectionRestitution, SectionRestitutionColumn, SectionRestitutionRow, Restitution } from '.';
 import {create} from "react-test-renderer";
 
-const RightTItle = () => {
+const RightTitle = () => {
   return (<a className="af-link af-link--hasIconLeft" href="#">
     <i className="glyphicon glyphicon-pencil"></i>
     <span className="af-link__text">Modifier</span>
@@ -11,7 +11,7 @@ const RightTItle = () => {
 };
 
 const Component = (<ArticleRestitution>
-  <HeaderRestitution  title="Tarifs" subtitle="Tout adhérent, assuré, base (sans EAC ou sans PAC)" rightTitle={<RightTItle/>}>
+  <HeaderRestitution  title="Tarifs" subtitle="Tout adhérent, assuré, base (sans EAC ou sans PAC)" rightTitle={<RightTitle/>}>
   </HeaderRestitution>
   <SectionRestitution >
     <SectionRestitutionRow title="Base de calcul des prestations">

--- a/packages/restitution/src/Restitution.spec.tsx
+++ b/packages/restitution/src/Restitution.spec.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
 
 import { ArticleRestitution, HeaderRestitution, SectionRestitution, SectionRestitutionColumn, SectionRestitutionRow, Restitution } from '.';
 import {create} from "react-test-renderer";
-import Badge from "../../badge/src/Badge";
 
-const TitleLeft = () => {
+const RightTItle = () => {
   return (<a className="af-link af-link--hasIconLeft" href="#">
     <i className="glyphicon glyphicon-pencil"></i>
     <span className="af-link__text">Modifier</span>
@@ -13,7 +11,7 @@ const TitleLeft = () => {
 };
 
 const Component = (<ArticleRestitution>
-  <HeaderRestitution  title="Tarifs" subtitle="Tout adhérent, assuré, base (sans EAC ou sans PAC)" titleLeft={<TitleLeft/>}>
+  <HeaderRestitution  title="Tarifs" subtitle="Tout adhérent, assuré, base (sans EAC ou sans PAC)" rightTitle={<RightTItle/>}>
   </HeaderRestitution>
   <SectionRestitution >
     <SectionRestitutionRow title="Base de calcul des prestations">

--- a/storybook/storybook/src/packages/restitution/src/Restitution.stories.js
+++ b/storybook/storybook/src/packages/restitution/src/Restitution.stories.js
@@ -8,7 +8,7 @@ import readme from '@axa-fr/react-toolkit-restitution/dist/README.md';
 
 const stories = [];
 
-const TitleLeft = () => {
+const RightTitle = () => {
   return (<a className="af-link af-link--hasIconLeft" href="#"><i className="glyphicon glyphicon-pencil"></i><span className="af-link__text">Modifier</span></a>)
   };
 
@@ -16,7 +16,7 @@ stories.push({
   desc: 'ArticleRestitution',
   component: () => (
     <ArticleRestitution>
-    <HeaderRestitution  title="Tarifs" subtitle="Tout adhérent, assuré, base (sans EAC ou sans PAC)" titleLeft={<TitleLeft/>}>
+    <HeaderRestitution  title="Tarifs" subtitle="Tout adhérent, assuré, base (sans EAC ou sans PAC)" rightTitle={<RightTitle/>}>
     </HeaderRestitution>
       <SectionRestitution >
         <SectionRestitutionRow title="Base de calcul des prestations">


### PR DESCRIPTION
### Reference to the issue

#346 

### Description of the issue

The `HeaderRestitution` component has a property `titleLeft` which add some content at the right of the restitution header.

This property should be called `rightTitle` as the content is displayed at the right.

### Person(s) for reviewing proposed changes

@guillaumechervet 