### PR TITLE
feat(ToolkitCore): Le texte ne passe plus en dessous des inputs.

### DIFF
--- a/packages/popover/src/popover.scss
+++ b/packages/popover/src/popover.scss
@@ -13,6 +13,8 @@ $size-arrow: 8px;
       color: $white;
       border-radius: 3px;
       padding: 0.5rem;
+      z-index: 100;
+      width: 260px;
 
       .af-subtitle {
         color: $white;
@@ -82,9 +84,9 @@ $size-arrow: 8px;
         }
       }
     }
-    &--small{
-      .af-btn{
-        &--circle{
+    &--small {
+      .af-btn {
+        &--circle {
           width: 2rem;
           height: 2rem;
         }


### PR DESCRIPTION
### Description of the issue

`When using the help button component beside another form component (text input for exemple), the popover appears below the input frame, with a default width that makes it hardly readable.`

### Person(s) for reviewing proposed changes

`You can add @samuel-gomez-axa @guillaumechervet  @guillaumechervetaxa `

# Important

Before creating a pull request run unit tests

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```