### PR TITLE
feat: onClick is no longer required on navbar and steplink

### DIFF
--- a/packages/Form/steps/src/StepLink.js
+++ b/packages/Form/steps/src/StepLink.js
@@ -8,7 +8,7 @@ const propTypes = {
   ...Constants.propTypes,
   id: PropTypes.string.isRequired,
   href: PropTypes.string,
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
   number: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   title: PropTypes.string.isRequired,
   icon: PropTypes.string,

--- a/packages/Layout/header/src/NavBar/NavBar.js
+++ b/packages/Layout/header/src/NavBar/NavBar.js
@@ -7,7 +7,7 @@ import { setPosition } from './NavBar.helpers';
 const propTypes = {
   ...Constants.propTypes,
   isVisible: PropTypes.bool.isRequired,
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
   id: PropTypes.string,
   toggleMenuId: PropTypes.string,
   children: PropTypes.node,

--- a/packages/Layout/header/src/NavBar/NavBarBase.js
+++ b/packages/Layout/header/src/NavBar/NavBarBase.js
@@ -6,7 +6,7 @@ import ToggleButton from '../ToggleButton';
 const propTypes = {
   ...Constants.propTypes,
   isVisible: PropTypes.bool.isRequired,
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
   handleKeys: PropTypes.func.isRequired,
   onFocus: PropTypes.func.isRequired,
   onBlur: PropTypes.func.isRequired,


### PR DESCRIPTION
## Related issue

### Description of the issue

onClick prop was required on some component. If you know other useless required prop, add them on this PR.

### Person(s) for reviewing proposed changes

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```