### PR TITLE
feat(checkbox): Add support for classModifier in items option

### DIFF
--- a/packages/Form/Input/checkbox/package.json
+++ b/packages/Form/Input/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-fr/react-toolkit-form-input-checkbox",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
   "private": false,

--- a/packages/Form/Input/checkbox/src/Checkbox.js
+++ b/packages/Form/Input/checkbox/src/Checkbox.js
@@ -9,21 +9,20 @@ import CheckboxItem from './CheckboxItem';
 const omitProperties = omit(['mode', 'id']);
 
 const Checkbox = ({
-                    classModifier,
-                    options,
-                    isVisible,
-                    disabled,
-                    name,
-                    onBlur,
-                    onFocus,
-                    readOnly,
-                    children,
-                    values,
-                    className,
-                    onChange,
-                    ...otherProps
-                  }) => {
-
+  classModifier,
+  options,
+  isVisible,
+  disabled,
+  name,
+  onBlur,
+  onFocus,
+  readOnly,
+  children,
+  values,
+  className,
+  onChange,
+  ...otherProps
+}) => {
   if (!options) {
     return null;
   }
@@ -45,7 +44,7 @@ const Checkbox = ({
         isVisible={isVisible}
         disabled={InputList.isDisabled(option, disabled)}
         className={className}
-        classModifier={classModifier}
+        classModifier={option.classModifier}
         {...omitProperties(otherProps)}>
         {children}
       </CheckboxItem>

--- a/packages/Form/Input/radio/package.json
+++ b/packages/Form/Input/radio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axa-fr/react-toolkit-form-input-radio",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
   "private": false,

--- a/packages/Form/Input/radio/src/Radio.js
+++ b/packages/Form/Input/radio/src/Radio.js
@@ -1,26 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { InputList, InputConstants as Constants, withInput, omit } from '@axa-fr/react-toolkit-form-core';
+import {
+  InputList,
+  InputConstants as Constants,
+  withInput,
+  omit,
+} from '@axa-fr/react-toolkit-form-core';
 import RadioItem from './RadioItem';
 import RadioModes from './RadioModes';
 
 const omitProperties = omit(['mode', 'helpMessage', 'id']);
 
 const Radio = ({
-                 isVisible,
-                 className,
-                 disabled,
-                 options,
-                 value,
-                 name,
-                 onBlur,
-                 onFocus,
-                 readOnly,
-                 classModifier,
-                 children,
-                 onChange,
-                 ...otherProps
-               }) => options.map(option => {
+  isVisible,
+  className,
+  disabled,
+  options,
+  value,
+  name,
+  onBlur,
+  onFocus,
+  readOnly,
+  classModifier,
+  children,
+  onChange,
+  ...otherProps
+}) =>
+  options.map(option => {
     const isChecked = option.value === value;
     return (
       <RadioItem
@@ -37,13 +43,12 @@ const Radio = ({
         isVisible={isVisible}
         disabled={InputList.isDisabled(option, disabled)}
         className={className}
-        classModifier={classModifier}
+        classModifier={option.classModifier}
         {...omitProperties(otherProps)}>
         {children}
       </RadioItem>
     );
   });
-
 
 const propTypes = {
   ...Constants.propTypes,


### PR DESCRIPTION
## Related issue

### Reference to the issue

Fixes #529 

### Description of the issue

I suggest adding support for the `classModifier` attribute in property `options` of the CheckboxInput/RadioInput like this :

```javascript
<CheckboxInput
        id="TheId"
        label="TheLabel"
        name="TheName"
        mode="classic"
        options={[{
             id: "id1",
             label: "Item 1",
             value: "value 1",
             disabled: false,
             classModifier: condition && "MY_STYLE"
        },
        {
             id: "id2,
             label: "Item 2",
             value: "value 2",
             disabled: false,
             classModifier: condition && "MY_STYLE"
        }]}
        values={value}
        onChange={onChange}
/>
```