### PR TITLE
fix(modal): type with correct react event type

### DIFF
--- a/packages/Modal/default/src/ModalCore.tsx
+++ b/packages/Modal/default/src/ModalCore.tsx
@@ -13,7 +13,7 @@ ReactModal.setAppElement('body');
 
 interface ModalCoreComponentProps {
   isOpen: boolean;
-  onOutsideTap: (event: MouseEvent | KeyboardEvent) => void;
+  onOutsideTap: (event: React.MouseEvent | React.KeyboardEvent) => void;
   className?: string;
 }
 


### PR DESCRIPTION
Prepare script onto modal/default package fail on ts compilation.

Cause by wrong Event type only for unit tests