### PR TITLE
feat(react-toolkit-form): add a red star on label of required fields

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,9 @@ $ npm run dev
 # [react] To edit a single component in live inside storybook, you have run js compilation in another bash process
 $ npx lerna exec --scope=@axa-fr/react-toolkit-table -- node ../../scripts/watch-js.js
 
+# [CSS] Generate CSS for storybook (does not watch, you have to run it manually)
+$ gulp all
+
 # [css] Develop html/css
 $ npm run css
 # [css] Build the html/css website

--- a/packages/Form/core/src/form.scss
+++ b/packages/Form/core/src/form.scss
@@ -20,6 +20,13 @@
     margin: 0;
   }
 
+  &__group--required &__group-label {
+    &:after {
+      content: '*';
+      color: $color-red-error;
+    }
+  }
+
   &__message {
     position: absolute;
     min-height: 1.6em;

--- a/storybook/storybook/src/packages/Form/Demo/Form.js
+++ b/storybook/storybook/src/packages/Form/Demo/Form.js
@@ -19,7 +19,8 @@ const Form = ({ handleChange, handleSubmit, form }) => (
       />
       <h3 className="af-subtitle">Informations</h3>
       <TextInput
-        label="Place name *"
+        label="Place name"
+        classModifier="required"
         name="placeName"
         onChange={handleChange}
         helpMessage="Enter the place name, ex : Webcenter"
@@ -33,14 +34,16 @@ const Form = ({ handleChange, handleSubmit, form }) => (
         </HelpButton>
       </TextInput>
       <TextInput
-        label="Author *"
+        label="Author"
+        classModifier="required"
         name="author"
         onChange={handleChange}
         helpMessage="Enter the author name, ex : Steve"
         {...form.author}
       />
       <DateInput
-        label="Date *"
+        label="Date"
+        classModifier="required"
         name="date"
         onChange={handleChange}
         helpMessage="Enter the actuel date"

--- a/storybook/storybook/src/packages/Form/Input/checkbox/src/CheckboxInput.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/checkbox/src/CheckboxInput.stories.js
@@ -67,6 +67,37 @@ const CheckboxInputStory = () => (
   </form>
 );
 
+const CheckboxInputStoryRequired = () => (
+  <form className="af-form" name="myform">
+    <CheckboxInput
+      label={text('label', 'Place type')}
+      name={text('name', 'placeType')}
+      id={text('id', 'inputuniqueid')}
+      mode={select('mode', modes, CheckboxModes.classic)}
+      options={options}
+      values={values}
+      onChange={action('onChange')}
+      helpMessage={text('helpMessage', 'Enter the place type')}
+      message={text('message', '')}
+      messageType={select('messageType', MessageTypes, MessageTypes.error)}
+      forceDisplayMessage={boolean('forceDisplayMessage', false)}
+      readOnly={boolean('readOnly', false)}
+      disabled={boolean('disabled', false)}
+      isVisible={boolean('isVisible', true)}
+      classModifier={text('classModifier', 'required')}
+      className={text('className', '')}
+      classNameContainerLabel={text(
+        'classNameContainerLabel',
+        InputConstants.defaultProps.classNameContainerLabel
+      )}
+      classNameContainerInput={text(
+        'classNameContainerInput',
+        InputConstants.defaultProps.classNameContainerInput
+      )}
+    />
+  </form>
+);
+
 const CheckboxInputDefaultStory = () => (
   <form className="af-form" name="myform">
     <CheckboxInput
@@ -238,6 +269,7 @@ stories.addParameters({
 stories.add('CheckboxItem', CheckboxItemStory);
 stories.add('Checkbox', CheckboxStory);
 stories.add('CheckboxInput Classic', CheckboxInputStory);
+stories.add('CheckboxInput Required', CheckboxInputStoryRequired);
 stories.add('CheckboxInput Default', CheckboxInputDefaultStory);
 stories.add('CheckboxInput Inline', CheckboxInputInlineStory);
 stories.add('CheckboxItem Toggle', CheckboxItemToggleStory);

--- a/storybook/storybook/src/packages/Form/Input/choice/src/ChoiceInput.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/choice/src/ChoiceInput.stories.js
@@ -15,7 +15,7 @@ import readme from '@axa-fr/react-toolkit-form-input-choice/dist/README.md';
 const ChoiceInputStory = () => (
   <form className="af-form" name="myform">
     <ChoiceInput
-      label={text('label', 'Place type *')}
+      label={text('label', 'Place type')}
       name={text('name', 'placeType')}
       id={text('id', 'uniqueid')}
       onChange={action('onChange')}
@@ -28,6 +28,35 @@ const ChoiceInputStory = () => (
       disabled={boolean('disabled', false)}
       isVisible={boolean('isVisible', true)}
       classModifier={text('classModifier', '')}
+      className={text('className', '')}
+      classNameContainerLabel={text(
+        'classNameContainerLabel',
+        InputConstants.defaultProps.classNameContainerLabel
+      )}
+      classNameContainerInput={text(
+        'classNameContainerInput',
+        InputConstants.defaultProps.classNameContainerInput
+      )}
+    />
+  </form>
+);
+
+const ChoiceInputStoryRequired = () => (
+  <form className="af-form" name="myform">
+    <ChoiceInput
+      label={text('label', 'Place type')}
+      name={text('name', 'placeType')}
+      id={text('id', 'uniqueid')}
+      onChange={action('onChange')}
+      value={boolean('value', null)}
+      helpMessage={text('helpMessage', 'Enter the place type')}
+      message={text('message', '')}
+      messageType={select('messageType', MessageTypes, MessageTypes.error)}
+      forceDisplayMessage={boolean('forceDisplayMessage', false)}
+      readOnly={boolean('readOnly', false)}
+      disabled={boolean('disabled', false)}
+      isVisible={boolean('isVisible', true)}
+      classModifier={text('classModifier', 'required')}
       className={text('className', '')}
       classNameContainerLabel={text(
         'classNameContainerLabel',
@@ -77,4 +106,5 @@ stories.addParameters({
 });
 
 stories.add('ChoiceInput', ChoiceInputStory);
+stories.add('ChoiceInput Required', ChoiceInputStoryRequired);
 stories.add('Choice', ChoiceStory);

--- a/storybook/storybook/src/packages/Form/Input/date-phone/src/DatePhoneInput.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/date-phone/src/DatePhoneInput.stories.js
@@ -16,7 +16,7 @@ import readme from '@axa-fr/react-toolkit-form-input-date-phone/dist/README.md';
 const DatePhoneInputStory = () => (
   <form className="af-form" name="myform">
     <DatePhoneInput
-      label={text('label', 'Place name *')}
+      label={text('label', 'Place name')}
       name={text('name', 'placeName')}
       id={text('id', 'uniqueid')}
       locale={text('locale', 'fr-fr')}
@@ -42,6 +42,37 @@ const DatePhoneInputStory = () => (
     />
   </form>
 );
+
+const DatePhoneInputStoryRequired = () => (
+  <form className="af-form" name="myform">
+    <DatePhoneInput
+      label={text('label', 'Place name')}
+      name={text('name', 'placeName')}
+      id={text('id', 'uniqueid')}
+      locale={text('locale', 'fr-fr')}
+      value={moment('11/26/2017', 'MM/DD/YYYY')}
+      onChange={action('onChange')}
+      helpMessage={text('helpMessage', 'jj/mm/aaaa')}
+      message={text('message', '')}
+      messageType={select('messageType', MessageTypes, MessageTypes.success)}
+      forceDisplayMessage={boolean('forceDisplayMessage', false)}
+      readOnly={boolean('readOnly', false)}
+      disabled={boolean('disabled', false)}
+      isVisible={boolean('isVisible', true)}
+      classModifier={text('classModifier', 'required')}
+      className={text('className', '')}
+      classNameContainerLabel={text(
+        'classNameContainerLabel',
+        InputConstants.defaultProps.classNameContainerLabel
+      )}
+      classNameContainerInput={text(
+        'classNameContainerInput',
+        InputConstants.defaultProps.classNameContainerInput
+      )}
+    />
+  </form>
+);
+
 const DatePhoneStory = () => (
   <form className="af-form" name="myform">
     <FieldForm
@@ -75,3 +106,4 @@ stories.addParameters({
 });
 stories.add('DatePhone', DatePhoneStory);
 stories.add('DatePhoneInput', DatePhoneInputStory);
+stories.add('DatePhoneInput Required', DatePhoneInputStoryRequired);

--- a/storybook/storybook/src/packages/Form/Input/date/src/DateInput.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/date/src/DateInput.stories.js
@@ -16,7 +16,7 @@ import readme from '@axa-fr/react-toolkit-form-input-date/dist/README.md';
 const DateInputStory = () => (
   <form className="af-form" name="myform">
     <DateInput
-      label={text('label', 'Place name *')}
+      label={text('label', 'Place name')}
       name={text('name', 'placeName')}
       id={text('id', 'uniqueid')}
       locale={text('locale', 'fr-fr')}
@@ -30,6 +30,43 @@ const DateInputStory = () => (
       disabled={boolean('disabled', false)}
       isVisible={boolean('isVisible', true)}
       classModifier={text('classModifier', '')}
+      className={text('className', '')}
+      classNameContainerLabel={text(
+        'classNameContainerLabel',
+        InputConstants.defaultProps.classNameContainerLabel
+      )}
+      classNameContainerInput={text(
+        'classNameContainerInput',
+        InputConstants.defaultProps.classNameContainerInput
+      )}
+      fixedHeight
+      showMonthDropdown
+      showYearDropdown
+      autoFocus={false}
+      todayButton={text('todayButton', "Aujourd'hui")}
+      popperPlacement="right-start"
+      yearDropdownItemNumber={6}
+    />
+  </form>
+);
+
+const DateInputStoryRequired = () => (
+  <form className="af-form" name="myform">
+    <DateInput
+      label={text('label', 'Place name')}
+      name={text('name', 'placeName')}
+      id={text('id', 'uniqueid')}
+      locale={text('locale', 'fr-fr')}
+      value={moment('11/26/2017', 'MM/DD/YYYY')}
+      onChange={action('onChange')}
+      helpMessage={text('helpMessage', 'jj/mm/aaaa')}
+      message={text('message', '')}
+      messageType={select('messageType', MessageTypes, MessageTypes.success)}
+      forceDisplayMessage={boolean('forceDisplayMessage', false)}
+      readOnly={boolean('readOnly', false)}
+      disabled={boolean('disabled', false)}
+      isVisible={boolean('isVisible', true)}
+      classModifier={text('classModifier', 'required')}
       className={text('className', '')}
       classNameContainerLabel={text(
         'classNameContainerLabel',
@@ -95,4 +132,5 @@ stories.addParameters({
 });
 
 stories.add('DateInputStory', DateInputStory);
+stories.add('DateInputStory Required', DateInputStoryRequired);
 stories.add('CustomDateStory', CustomDateStory);

--- a/storybook/storybook/src/packages/Form/Input/file/src/FileInput.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/file/src/FileInput.stories.js
@@ -17,7 +17,7 @@ import readme from '@axa-fr/react-toolkit-form-input-file/dist/README.md';
 const FileInputStory = () => (
   <form className="af-form" name="myform">
     <FileInput
-      label={text('label', 'Image *')}
+      label={text('label', 'Image')}
       name={text('name', 'placeImage')}
       id={text('id', 'uniqueid')}
       accept={text('accept', 'image/jpeg, image/png, application/*')}
@@ -31,6 +31,36 @@ const FileInputStory = () => (
       readOnly={boolean('readOnly', false)}
       disabled={boolean('disabled', false)}
       classModifier={text('classModifier', '')}
+      className={text('className', '')}
+      classNameContainerLabel={text(
+        'classNameContainerLabel',
+        InputConstants.defaultProps.classNameContainerLabel
+      )}
+      classNameContainerInput={text(
+        'classNameContainerInput',
+        InputConstants.defaultProps.classNameContainerInput
+      )}
+    />
+  </form>
+);
+
+const FileInputStoryRequired = () => (
+  <form className="af-form" name="myform">
+    <FileInput
+      label={text('label', 'Image')}
+      name={text('name', 'placeImage')}
+      id={text('id', 'uniqueid')}
+      accept={text('accept', 'image/jpeg, image/png, application/*')}
+      onChange={action('onChange')}
+      helpMessage={text('helpMessage', 'Take a photo af a place')}
+      message={text('message', '')}
+      messageType={select('messageType', MessageTypes, MessageTypes.error)}
+      forceDisplayMessage={boolean('forceDisplayMessage', false)}
+      multiple={boolean('multiple', true)}
+      isVisible={boolean('isVisible', true)}
+      readOnly={boolean('readOnly', false)}
+      disabled={boolean('disabled', false)}
+      classModifier={text('classModifier', 'required')}
       className={text('className', '')}
       classNameContainerLabel={text(
         'classNameContainerLabel',
@@ -108,7 +138,6 @@ const values = [
       type: 'image',
     },
   },
-  ,
   {
     id: '000005',
     file: {
@@ -190,3 +219,4 @@ stories.add('File', FileStory);
 stories.add('File with values', FileWithValuesStory);
 stories.add('File with errors', FileWithErrorsStory);
 stories.add('FileInput', FileInputStory);
+stories.add('FileInput Required', FileInputStoryRequired);

--- a/storybook/storybook/src/packages/Form/Input/number/src/NumberInput.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/number/src/NumberInput.stories.js
@@ -16,7 +16,7 @@ import readme from '@axa-fr/react-toolkit-form-input-number/dist/README.md';
 const NumberInputStory = () => (
   <form className="af-form" name="myform">
     <NumberInput
-      label={text('label', 'Place name *')}
+      label={text('label', 'Place name')}
       name={text('name', 'placeName')}
       id={text('id', 'uniqueid')}
       onChange={action('onChange')}
@@ -31,6 +31,40 @@ const NumberInputStory = () => (
       disabled={boolean('disabled', false)}
       isVisible={boolean('isVisible', true)}
       classModifier={text('classModifier', '')}
+      className={text('className', '')}
+      tabIndex={text('tabIndex', '')}
+      autoFocus={boolean('autoFocus', true)}
+      classNameContainerLabel={text(
+        'classNameContainerLabel',
+        InputConstants.defaultProps.classNameContainerLabel
+      )}
+      classNameContainerInput={text(
+        'classNameContainerInput',
+        InputConstants.defaultProps.classNameContainerInput
+      )}>
+      <Help>tooltip avec du text</Help>
+    </NumberInput>
+  </form>
+);
+
+const NumberInputStoryRequired = () => (
+  <form className="af-form" name="myform">
+    <NumberInput
+      label={text('label', 'Place name')}
+      name={text('name', 'placeName')}
+      id={text('id', 'uniqueid')}
+      onChange={action('onChange')}
+      value={number('value', null)}
+      viewValue={text('viewValue', '')}
+      helpMessage={text('helpMessage', 'Enter the place name, ex : Webcenter')}
+      placeholder={text('placeholder', '')}
+      message={text('message', '')}
+      messageType={select('messageType', MessageTypes, MessageTypes.error)}
+      forceDisplayMessage={boolean('forceDisplayMessage', false)}
+      readOnly={boolean('readOnly', false)}
+      disabled={boolean('disabled', false)}
+      isVisible={boolean('isVisible', true)}
+      classModifier={text('classModifier', 'required')}
       className={text('className', '')}
       tabIndex={text('tabIndex', '')}
       autoFocus={boolean('autoFocus', true)}
@@ -88,3 +122,4 @@ stories.addParameters({
 
 stories.add('Number', NumberStory);
 stories.add('NumberInput', NumberInputStory);
+stories.add('NumberInput Required', NumberInputStoryRequired);

--- a/storybook/storybook/src/packages/Form/Input/pass/src/PassInput.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/pass/src/PassInput.stories.js
@@ -69,7 +69,7 @@ const PassInputStory = () => (
       <PassInput
         id={text('id', 'uniqueid')}
         score={select('score', [null, 0, 1, 2, 3, 4], 0)}
-        label={text('label', 'Password *')}
+        label={text('label', 'Password')}
         name={text('name', 'password')}
         onChange={action('onChange')}
         onToggleType={action('onToggleType')}
@@ -99,6 +99,42 @@ const PassInputStory = () => (
   </form>
 );
 
+const PassInputStoryRequired = () => (
+  <form className="af-form" name="myform">
+    <div>
+      <PassInput
+        id={text('id', 'uniqueid')}
+        score={select('score', [null, 0, 1, 2, 3, 4], 0)}
+        label={text('label', 'Password')}
+        name={text('name', 'password')}
+        onChange={action('onChange')}
+        onToggleType={action('onToggleType')}
+        value={text('value', '')}
+        helpMessage={text('helpMessage', '8 caractères minimum')}
+        message={text('message', '')}
+        messageType={select('messageType', MessageTypes, MessageTypes.error)}
+        forceDisplayMessage={boolean('forceDisplayMessage', false)}
+        readOnly={boolean('readOnly', false)}
+        disabled={boolean('disabled', false)}
+        isVisible={boolean('isVisible', true)}
+        classModifier={text('classModifier', 'required')}
+        className={text('className', '')}
+        tabIndex={text('tabIndex', '')}
+        autoFocus={boolean('autoFocus', true)}
+        classNameContainerLabel={text(
+          'classNameContainerLabel',
+          InputConstants.defaultProps.classNameContainerLabel
+        )}
+        classNameContainerInput={text(
+          'classNameContainerInput',
+          InputConstants.defaultProps.classNameContainerInput
+        )}>
+        <HelpButton>Choose a password</HelpButton>
+      </PassInput>
+    </div>
+  </form>
+);
+
 const stories = storiesOf('Form.Input.Pass', module);
 
 stories.addParameters({
@@ -109,3 +145,4 @@ stories.addParameters({
 
 stories.add('Pass', PassStory);
 stories.add('PassInput', PassInputStory);
+stories.add('PassInput Required', PassInputStoryRequired);

--- a/storybook/storybook/src/packages/Form/Input/radio/src/RadioInput.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/radio/src/RadioInput.stories.js
@@ -29,7 +29,7 @@ const modes = [RadioModes.classic, RadioModes.default, RadioModes.inline];
 const RadioInputStory = () => (
   <form className="af-form" name="myform">
     <RadioInput
-      label={text('label', 'Place type *')}
+      label={text('label', 'Place type')}
       name={text('name', 'placeType')}
       id={text('id', '')}
       options={options}
@@ -57,10 +57,41 @@ const RadioInputStory = () => (
   </form>
 );
 
+const RadioInputStoryRequired = () => (
+  <form className="af-form" name="myform">
+    <RadioInput
+      label={text('label', 'Place type')}
+      name={text('name', 'placeType')}
+      id={text('id', '')}
+      options={options}
+      onChange={action('onChange')}
+      mode={select('mode', modes, RadioModes.default)}
+      value={text('value', '')}
+      helpMessage={text('helpMessage', 'Enter the place type')}
+      message={text('message', '')}
+      messageType={select('messageType', MessageTypes, MessageTypes.error)}
+      forceDisplayMessage={boolean('forceDisplayMessage', false)}
+      readOnly={boolean('readOnly', false)}
+      disabled={boolean('disabled', false)}
+      isVisible={boolean('isVisible', true)}
+      classModifier={text('classModifier', 'required')}
+      className={text('className', '')}
+      classNameContainerLabel={text(
+        'classNameContainerLabel',
+        InputConstants.defaultProps.classNameContainerLabel
+      )}
+      classNameContainerInput={text(
+        'classNameContainerInput',
+        InputConstants.defaultProps.classNameContainerInput
+      )}
+    />
+  </form>
+);
+
 const RadioClassicInputStory = () => (
   <form className="af-form" name="myform">
     <RadioInput
-      label={text('label', 'Place type *')}
+      label={text('label', 'Place type')}
       name={text('name', 'placeType')}
       id={text('id', '')}
       options={options}
@@ -91,7 +122,7 @@ const RadioClassicInputStory = () => (
 const RadioInlineInputStory = () => (
   <form className="af-form" name="myform">
     <RadioInput
-      label={text('label', 'Place type *')}
+      label={text('label', 'Place type')}
       name={text('name', 'placeType')}
       id={text('id', '')}
       options={options}
@@ -122,7 +153,7 @@ const RadioInlineInputStory = () => (
 const RadioInputWithChildrenStory = () => (
   <form className="af-form" name="myform">
     <RadioInput
-      label={text('label', 'Place type *')}
+      label={text('label', 'Place type')}
       name={text('name', 'placeType')}
       id={text('id', '')}
       options={options}
@@ -213,6 +244,7 @@ stories.addParameters({
 stories.add('RadioItem', RadioItemStory);
 stories.add('Radio', RadioStory);
 stories.add('RadioInput Default', RadioInputStory);
+stories.add('RadioInput Default Required', RadioInputStoryRequired);
 stories.add('RadioInput Classic', RadioClassicInputStory);
 stories.add('RadioInput Inline', RadioInlineInputStory);
 stories.add('Radio with children', RadioInputWithChildrenStory);

--- a/storybook/storybook/src/packages/Form/Input/select-multi/src/MultiSelectInput.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/select-multi/src/MultiSelectInput.stories.js
@@ -31,7 +31,7 @@ const values = ['fun', 'drink'];
 const MultiSelectInputStory = () => (
   <form className="af-form" name="myform">
     <MultiSelectInput
-      label={text('label', 'Place type *')}
+      label={text('label', 'Place type')}
       name={text('name', 'placeType')}
       options={options}
       onChange={action('onChange')}
@@ -44,6 +44,36 @@ const MultiSelectInputStory = () => (
       disabled={boolean('disabled', false)}
       isVisible={boolean('isVisible', true)}
       classModifier={text('classModifier', '')}
+      className={text('className', '')}
+      placeholder={text('placeholder', 'Select')}
+      classNameContainerLabel={text(
+        'classNameContainerLabel',
+        InputConstants.defaultProps.classNameContainerLabel
+      )}
+      classNameContainerInput={text(
+        'classNameContainerInput',
+        InputConstants.defaultProps.classNameContainerInput
+      )}
+    />
+  </form>
+);
+
+const MultiSelectInputStoryRequired = () => (
+  <form className="af-form" name="myform">
+    <MultiSelectInput
+      label={text('label', 'Place type')}
+      name={text('name', 'placeType')}
+      options={options}
+      onChange={action('onChange')}
+      values={values}
+      helpMessage={text('helpMessage', 'Enter the place type')}
+      message={text('message', '')}
+      messageType={select('messageType', MessageTypes, MessageTypes.error)}
+      forceDisplayMessage={boolean('forceDisplayMessage', false)}
+      readOnly={boolean('readOnly', false)}
+      disabled={boolean('disabled', false)}
+      isVisible={boolean('isVisible', true)}
+      classModifier={text('classModifier', 'required')}
       className={text('className', '')}
       placeholder={text('placeholder', 'Select')}
       classNameContainerLabel={text(
@@ -89,7 +119,7 @@ const MultiSelectStory = () => (
 const MultiSelectWithOneValueStory = () => (
   <form className="af-form" name="myform">
     <MultiSelectInput
-      label={text('label', 'Place type *')}
+      label={text('label', 'Place type')}
       name={text('name', 'placeType')}
       options={options}
       onChange={action('onChange')}
@@ -127,4 +157,5 @@ stories.addParameters({
 
 stories.add('MultiSelect', MultiSelectStory);
 stories.add('MultiSelectInput', MultiSelectInputStory);
+stories.add('MultiSelectInput Required', MultiSelectInputStoryRequired);
 stories.add('MultiSelect one value', MultiSelectWithOneValueStory);

--- a/storybook/storybook/src/packages/Form/Input/select/src/SelectInput.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/select/src/SelectInput.stories.js
@@ -26,7 +26,7 @@ const options = [
 const SelectInputStory = () => (
   <form className="af-form" name="myform">
     <SelectInput
-      label={text('label', 'Place type *')}
+      label={text('label', 'Place type')}
       name={text('name', 'placeName')}
       id={text('id', 'muid')}
       helpMessage={text('helpMessage', 'Enter the place type')}
@@ -37,6 +37,39 @@ const SelectInputStory = () => (
       disabled={boolean('disabled', false)}
       isVisible={boolean('isVisible', true)}
       classModifier={text('classModifier', '')}
+      className={text('className', '')}
+      placeholder={text('placeholder', '- Select -')}
+      message={text('message', '')}
+      messageType={select('messageType', MessageTypes, MessageTypes.error)}
+      forceDisplayMessage={boolean('forceDisplayMessage', false)}
+      mode={select('mode', SelectModes, SelectModes.default)}
+      classNameContainerLabel={text(
+        'classNameContainerLabel',
+        InputConstants.defaultProps.classNameContainerLabel
+      )}
+      classNameContainerInput={text(
+        'classNameContainerInput',
+        InputConstants.defaultProps.classNameContainerInput
+      )}
+      forceDisplayPlaceholder={boolean('forceDisplayPlaceholder', false)}
+    />
+  </form>
+);
+
+const SelectInputStoryRequired = () => (
+  <form className="af-form" name="myform">
+    <SelectInput
+      label={text('label', 'Place type')}
+      name={text('name', 'placeName')}
+      id={text('id', 'muid')}
+      helpMessage={text('helpMessage', 'Enter the place type')}
+      onChange={action('onChange')}
+      options={options}
+      value={text('value', '')}
+      readOnly={boolean('readOnly', false)}
+      disabled={boolean('disabled', false)}
+      isVisible={boolean('isVisible', true)}
+      classModifier={text('classModifier', 'required')}
       className={text('className', '')}
       placeholder={text('placeholder', '- Select -')}
       message={text('message', '')}
@@ -160,3 +193,4 @@ stories.add('SelectBase', SelectBaseStory);
 stories.add('Select', SelectStory);
 stories.add('Select keep placeholder', SelectKeepPlaceholderStory);
 stories.add('SelectInput', SelectInputStory);
+stories.add('SelectInput Required', SelectInputStoryRequired);

--- a/storybook/storybook/src/packages/Form/Input/slider/src/Slider.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/slider/src/Slider.stories.js
@@ -25,7 +25,7 @@ const SliderInputStory = () => (
     <SliderInput
       options={options}
       id={text('id', 'uniqueid')}
-      label={text('label', 'Place name *')}
+      label={text('label', 'Place name')}
       name={text('name', 'placeName')}
       onChange={action('onChange')}
       value={number('value', '1024')}
@@ -38,6 +38,37 @@ const SliderInputStory = () => (
       disabled={boolean('disabled', false)}
       isVisible={boolean('isVisible', true)}
       classModifier={text('classModifier', '')}
+      className={text('className', '')}
+      classNameContainerLabel={text(
+        'classNameContainerLabel',
+        Constants.defaultProps.classNameContainerLabel
+      )}
+      classNameContainerInput={text(
+        'classNameContainerInput',
+        Constants.defaultProps.classNameContainerInput
+      )}
+    />
+  </form>
+);
+
+const SliderInputStoryRequired = () => (
+  <form className="af-form" name="myform">
+    <SliderInput
+      options={options}
+      id={text('id', 'uniqueid')}
+      label={text('label', 'Place name')}
+      name={text('name', 'placeName')}
+      onChange={action('onChange')}
+      value={number('value', '1024')}
+      helpMessage={text('helpMessage', 'Enter the place name, ex : Webcenter')}
+      placeholder={text('placeholder', '')}
+      message={text('message', '')}
+      messageType={select('messageType', MessageTypes, MessageTypes.error)}
+      forceDisplayMessage={boolean('forceDisplayMessage', false)}
+      readOnly={boolean('readOnly', false)}
+      disabled={boolean('disabled', false)}
+      isVisible={boolean('isVisible', true)}
+      classModifier={text('classModifier', 'required')}
       className={text('className', '')}
       classNameContainerLabel={text(
         'classNameContainerLabel',
@@ -79,3 +110,4 @@ stories.addParameters({
 
 stories.add('Slider', SliderStory);
 stories.add('SliderInput', SliderInputStory);
+stories.add('SliderInput Required', SliderInputStoryRequired);

--- a/storybook/storybook/src/packages/Form/Input/switch/src/Switch.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/switch/src/Switch.stories.js
@@ -132,6 +132,39 @@ const SwitchInputStory = () => (
   />
 );
 
+const SwitchInputStoryRequired = () => (
+  <SwitchInput
+    label={text('label', 'Select a choice')}
+    name={text(KNOBS_LABELS.SwitchInput.name, LABELS.SwitchInput.name)}
+    value={select(
+      KNOBS_LABELS.SwitchInput.value,
+      LABELS.SwitchInput.values,
+      LABELS.SwitchInput.defaultValue
+    )}
+    disabled={boolean(
+      KNOBS_LABELS.SwitchInput.disabled,
+      LABELS.SwitchInput.disabled
+    )}
+    isVisible={boolean(
+      KNOBS_LABELS.SwitchInput.isVisible,
+      LABELS.SwitchInput.isVisible
+    )}
+    classModifier={text(
+      KNOBS_LABELS.SwitchInput.classModifier,
+      'required'
+    )}
+    className={text(
+      KNOBS_LABELS.SwitchInput.className,
+      LABELS.SwitchInput.className
+    )}
+    options={options}
+    onChange={action('onChange')}
+    message={text('message', '')}
+    messageType={select('messageType', MessageTypes, MessageTypes.error)}
+    forceDisplayMessage={boolean('forceDisplayMessage', false)}
+  />
+);
+
 const stories = storiesOf('Form.Input.Switch', module);
 
 stories.addParameters({
@@ -142,3 +175,4 @@ stories.addParameters({
 
 stories.add('Switch', SwitchStory);
 stories.add('SwitchInput', SwitchInputStory);
+stories.add('SwitchInput Required', SwitchInputStoryRequired);

--- a/storybook/storybook/src/packages/Form/Input/text/src/TextInput.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/text/src/TextInput.stories.js
@@ -18,7 +18,7 @@ const TextInputStory = () => (
   <form className="af-form" name="myform">
     <TextInput
       id={text('id', 'uniqueid')}
-      label={text('label', 'Place name *')}
+      label={text('label', 'Place name')}
       name={text('name', 'placeName')}
       onChange={action('onChange')}
       value={text('value', '')}
@@ -47,11 +47,44 @@ const TextInputStory = () => (
   </form>
 );
 
+const TextInputStoryRequired = () => (
+  <form className="af-form" name="myform">
+    <TextInput
+      id={text('id', 'uniqueid')}
+      label={text('label', 'Place name')}
+      name={text('name', 'placeName')}
+      onChange={action('onChange')}
+      value={text('value', '')}
+      helpMessage={text('helpMessage', 'Enter the place name, ex : Webcenter')}
+      placeholder={text('placeholder', '')}
+      message={text('message', '')}
+      messageType={select('messageType', MessageTypes, MessageTypes.error)}
+      forceDisplayMessage={boolean('forceDisplayMessage', false)}
+      readOnly={boolean('readOnly', false)}
+      disabled={boolean('disabled', false)}
+      isVisible={boolean('isVisible', true)}
+      classModifier={text('classModifier', 'required')}
+      className={text('className', '')}
+      tabIndex={text('tabIndex', '')}
+      autoFocus={boolean('autoFocus', true)}
+      classNameContainerLabel={text(
+        'classNameContainerLabel',
+        Constants.defaultProps.classNameContainerLabel
+      )}
+      classNameContainerInput={text(
+        'classNameContainerInput',
+        Constants.defaultProps.classNameContainerInput
+      )}>
+      <HelpButton>tooltip avec du text</HelpButton>
+    </TextInput>
+  </form>
+);
+
 const TextInputErrorStory = () => (
   <form className="af-form" name="myform">
     <TextInput
       id={text('id', 'uniqueid')}
-      label={text('label', 'Place name *')}
+      label={text('label', 'Place name')}
       name={text('name', 'placeName')}
       onChange={action('onChange')}
       value={text('value', '')}
@@ -63,7 +96,7 @@ const TextInputErrorStory = () => (
       readOnly={boolean('readOnly', false)}
       disabled={boolean('disabled', false)}
       isVisible={boolean('isVisible', true)}
-      classModifier={text('classModifier', '')}
+      classModifier={text('classModifier', 'required')}
       className={text('className', '')}
       tabIndex={text('tabIndex', '')}
       autoFocus={boolean('autoFocus', false)}
@@ -217,4 +250,5 @@ stories.add('Text Error', TextErrorStory);
 stories.add('Text Success', TextSuccessStory);
 stories.add('Text Disabled', TextDisabledStory);
 stories.add('TextInput', TextInputStory);
+stories.add('TextInput Required', TextInputStoryRequired);
 stories.add('TextInput Error', TextInputErrorStory);

--- a/storybook/storybook/src/packages/Form/Input/textarea/src/Textarea.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/textarea/src/Textarea.stories.js
@@ -19,7 +19,7 @@ import readme from '@axa-fr/react-toolkit-form-input-textarea/dist/README.md';
 const TextareaInputStory = () => (
   <form className="af-form" name="myform">
     <TextareaInput
-      label={text('label', 'Place type *')}
+      label={text('label', 'Place type')}
       name={text('name', 'placeType')}
       id={text('id', 'uinqid')}
       onChange={action('onChange')}
@@ -35,6 +35,40 @@ const TextareaInputStory = () => (
       disabled={boolean('disabled', false)}
       isVisible={boolean('isVisible', true)}
       classModifier={text('classModifier', '')}
+      className={text('className', '')}
+      tabIndex={text('tabIndex', null)}
+      autoFocus={boolean('autoFocus', true)}
+      classNameContainerLabel={text(
+        'classNameContainerLabel',
+        InputConstants.defaultProps.classNameContainerLabel
+      )}
+      classNameContainerInput={text(
+        'classNameContainerInput',
+        InputConstants.defaultProps.classNameContainerInput
+      )}
+    />
+  </form>
+);
+
+const TextareaInputStoryRequired = () => (
+  <form className="af-form" name="myform">
+    <TextareaInput
+      label={text('label', 'Place type')}
+      name={text('name', 'placeType')}
+      id={text('id', 'uinqid')}
+      onChange={action('onChange')}
+      value={text('value', '')}
+      rows={number('rows', 6)}
+      cols={number('cols', 60)}
+      placeholder={text('placeholder', '')}
+      helpMessage={text('helpMessage', 'Enter the place type')}
+      message={text('message', '')}
+      messageType={select('messageType', MessageTypes, MessageTypes.error)}
+      forceDisplayMessage={boolean('forceDisplayMessage', false)}
+      readOnly={boolean('readOnly', false)}
+      disabled={boolean('disabled', false)}
+      isVisible={boolean('isVisible', true)}
+      classModifier={text('classModifier', 'required')}
       className={text('className', '')}
       tabIndex={text('tabIndex', null)}
       autoFocus={boolean('autoFocus', true)}
@@ -90,3 +124,4 @@ stories.addParameters({
 
 stories.add('Textarea', TextareaStory);
 stories.add('TextareaInput', TextareaInputStory);
+stories.add('TextareaInput Required', TextareaInputStoryRequired);


### PR DESCRIPTION
Automatically add a red star on label of required fields.

Sample render (from storybook):
<img width="494" alt="Required field" src="https://user-images.githubusercontent.com/686305/81947410-cbb49f80-9600-11ea-87e9-e2170a177df3.png">

To migrate from old manual star to new automatic red star:
```diff
<TextInput
-  label="My label *"
+  label="My label"
+  classModifier="required"
 {...otherProps}
</TextInput>
```

cc @guillaume-chervet @samuel-gomez  @youf-olivier 
