### PR TITLE
build(TypeScript): expose typings

### DIFF
--- a/packages/Form/summary/package.json
+++ b/packages/Form/summary/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
     "prepare": "node ../../../scripts/prepare.js"

--- a/packages/Layout/footer/package.json
+++ b/packages/Layout/footer/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
     "prepare": "node ../../../scripts/prepare.js"

--- a/packages/Modal/default/package.json
+++ b/packages/Modal/default/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
     "prepare": "node ../../../scripts/prepare.js"

--- a/packages/action/package.json
+++ b/packages/action/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"

--- a/packages/restitution/package.json
+++ b/packages/restitution/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"

--- a/packages/title/package.json
+++ b/packages/title/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.11",
   "main": "dist/index.js",
   "jsnext:main": "src/index.js",
+  "types": "dist/index.d.ts",
   "private": false,
   "scripts": {
     "prepare": "node ../../scripts/prepare.js"


### PR DESCRIPTION
Add types declaration files to `package.json` for packages written in TypeScript.

People using TypeScript can remove their declaration for components from the following packages:
- @axa-fr/react-toolkit-action
- @axa-fr/react-toolkit-alert
- @axa-fr/react-toolkit-badge
- @axa-fr/react-toolkit-button
- @axa-fr/react-toolkit-core
- @axa-fr/react-toolkit-form-summary
- @axa-fr/react-toolkit-icon
- @axa-fr/react-toolkit-layout-footer
- @axa-fr/react-toolkit-modal-default
- @axa-fr/react-toolkit-restitution
- @axa-fr/react-toolkit-table
- @axa-fr/react-toolkit-tabs
- @axa-fr/react-toolkit-title

@samuel-gomez @guillaumechervet @youf-olivier 