### PR TITLE
refactor(react-toolkit-form): rollback remove use of componentWillUpdate

### DIFF
--- a/packages/Form/core/src/FieldForm.js
+++ b/packages/Form/core/src/FieldForm.js
@@ -132,6 +132,19 @@ class FieldForm extends Component {
     };
   }
 
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    const { forceDisplayMessage, message, messageType } = this.props;
+    if (forceDisplayMessage !== nextProps.forceDisplayMessage) {
+      this.setState({
+        memory: {
+          message,
+          messageType,
+        },
+      });
+    }
+  }
+
   render() {
     const { children } = this.props;
     const { message, messageType } = this.getInfo();


### PR DESCRIPTION
Rollback #613 because `forceDisplayMessage` didn't work anymore

I used the UNSAFE version of componentWillReceiveProps instead of removing it.

We need to be able to create a unit test but I don't know how...