### PR TITLE
build: bump react-select to version 3.1.0

### DIFF
--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -58,7 +58,7 @@
     "react-dropzone": "^7.0.1",
     "react-modal": "^3.11.1",
     "react-router-dom": "^5.1.2",
-    "react-select": "^2.4.4"
+    "react-select": "^3.1.0"
   },
   "scripts": {
     "start": "concurrently \"npm run server\" \"npm run start:app\"",

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,31 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-module-imports": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
+      "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
+      "requires": {
+        "@babel/types": "^7.10.1"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        }
+      }
+    },
     "@babel/helper-split-export-declaration": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
@@ -87,6 +112,11 @@
       "requires": {
         "@babel/types": "^7.0.0"
       }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
     },
     "@babel/helpers": {
       "version": "7.2.0",
@@ -197,62 +227,100 @@
       }
     },
     "@emotion/cache": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.0.tgz",
-      "integrity": "sha512-1/sT6GNyvWmxCtJek8ZDV+b+a+NMDx8/61UTnnF3rqrTY7bLTjw+fmXO7WgUIH0owuWKxza/J/FfAWC/RU4G7A==",
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
       "requires": {
-        "@emotion/sheet": "0.9.2",
-        "@emotion/stylis": "0.8.3",
-        "@emotion/utils": "0.11.1",
-        "@emotion/weak-memoize": "0.2.2"
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "@emotion/core": {
+      "version": "10.0.28",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.28.tgz",
+      "integrity": "sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
+      }
+    },
+    "@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "requires": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
       }
     },
     "@emotion/hash": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.1.tgz",
-      "integrity": "sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@emotion/memoize": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz",
-      "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg=="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "@emotion/serialize": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.3.tgz",
-      "integrity": "sha512-6Q+XH/7kMdHwtylwZvdkOVMydaGZ989axQ56NF7urTR7eiDMLGun//pFUy31ha6QR4C6JB+KJVhZ3AEAJm9Z1g==",
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
       "requires": {
-        "@emotion/hash": "0.7.1",
-        "@emotion/memoize": "0.7.1",
-        "@emotion/unitless": "0.7.3",
-        "@emotion/utils": "0.11.1",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
         "csstype": "^2.5.7"
       }
     },
     "@emotion/sheet": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.2.tgz",
-      "integrity": "sha512-pVBLzIbC/QCHDKJF2E82V2H/W/B004mDFQZiyo/MSR+VC4pV5JLG0TF/zgQDFvP3fZL/5RTPGEmXlYJBMUuJ+A=="
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
     },
     "@emotion/stylis": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.3.tgz",
-      "integrity": "sha512-M3nMfJ6ndJMYloSIbYEBq6G3eqoYD41BpDOxreE8j0cb4fzz/5qvmqU9Mb2hzsXcCnIlGlWhS03PCzVGvTAe0Q=="
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
     },
     "@emotion/unitless": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
-      "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@emotion/utils": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.1.tgz",
-      "integrity": "sha512-8M3VN0hetwhsJ8dH8VkVy7xo5/1VoBsDOk/T4SJOeXwTO1c4uIqVNx2qyecLFnnUWD5vvUqHQ1gASSeUN6zcTg=="
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
     },
     "@emotion/weak-memoize": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz",
-      "integrity": "sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA=="
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.2",
@@ -2713,7 +2781,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -3594,6 +3661,23 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-emotion": {
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      }
+    },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
@@ -3661,7 +3745,6 @@
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.5.tgz",
       "integrity": "sha512-+/9yteNQw3yuZ3krQUfjAeoT/f4EAdn3ELwhFfDj0rTMIaoHfIdrcLePOfIaL0qmFLpIcgPIL2Lzm58h+CGWaw==",
-      "dev": true,
       "requires": {
         "cosmiconfig": "^5.0.5",
         "resolve": "^1.8.1"
@@ -3671,7 +3754,6 @@
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
           "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
-          "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
           }
@@ -3753,8 +3835,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "dev": true
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -5596,7 +5677,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-      "dev": true,
       "requires": {
         "callsites": "^2.0.0"
       }
@@ -5605,7 +5685,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-      "dev": true,
       "requires": {
         "caller-callsite": "^2.0.0"
       }
@@ -5619,8 +5698,7 @@
     "callsites": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-      "dev": true
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
     },
     "camel-case": {
       "version": "3.0.0",
@@ -7106,7 +7184,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
       }
@@ -7385,7 +7462,6 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
       "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
-      "dev": true,
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
@@ -7473,17 +7549,6 @@
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.0.0"
-      }
-    },
-    "create-emotion": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.6.tgz",
-      "integrity": "sha512-pfaSo7swLlmHxizPYF5Oi09e1uPseueX/CirE6mZpPeeoH1Yb4I2cmx0VCN6KlCRko4yKFTErorect9y0+ARZQ==",
-      "requires": {
-        "@emotion/cache": "10.0.0",
-        "@emotion/serialize": "^0.11.3",
-        "@emotion/sheet": "0.9.2",
-        "@emotion/utils": "0.11.1"
       }
     },
     "create-error-class": {
@@ -9021,7 +9086,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -9190,8 +9254,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.11.0",
@@ -9777,8 +9840,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.0.1",
@@ -10694,6 +10756,11 @@
       "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
       "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
       "dev": true
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "find-up": {
       "version": "3.0.0",
@@ -14404,7 +14471,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-      "dev": true,
       "requires": {
         "caller-path": "^2.0.0",
         "resolve-from": "^3.0.0"
@@ -14413,8 +14479,7 @@
         "resolve-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-          "dev": true
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
         }
       }
     },
@@ -14721,8 +14786,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -14812,8 +14876,7 @@
     "is-directory": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-      "dev": true
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -16343,7 +16406,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -16439,8 +16501,7 @@
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -17595,8 +17656,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._arraymap": {
       "version": "3.0.0",
@@ -18463,9 +18523,9 @@
       }
     },
     "memoize-one": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
-      "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
     },
     "memoizee": {
       "version": "0.4.14",
@@ -20431,7 +20491,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "dev": true,
       "requires": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
@@ -20555,8 +20614,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-root": {
       "version": "0.1.1",
@@ -23896,7 +23954,7 @@
     },
     "react": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/react/-/react-16.13.1.tgz",
       "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
       "dev": true,
       "requires": {
@@ -23947,7 +24005,7 @@
     },
     "react-dom": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/react-dom/-/react-dom-16.13.1.tgz",
       "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
       "dev": true,
       "requires": {
@@ -23959,7 +24017,7 @@
       "dependencies": {
         "scheduler": {
           "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/scheduler/-/scheduler-0.19.1.tgz",
           "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
           "dev": true,
           "requires": {
@@ -23985,9 +24043,9 @@
       "dev": true
     },
     "react-input-autosize": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.1.tgz",
-      "integrity": "sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
+      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
       "requires": {
         "prop-types": "^15.5.8"
       }
@@ -26193,17 +26251,58 @@
       }
     },
     "react-select": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-2.2.0.tgz",
-      "integrity": "sha512-FOnsm/zrJ2pZvYsEfs58Xvru0SHL1jXAZTCFTWcOxmQSnRKgYuXUDFdpDiET90GLtJEF+t6BaZeD43bUH6/NZQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.1.0.tgz",
+      "integrity": "sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==",
       "requires": {
-        "classnames": "^2.2.5",
-        "create-emotion": "^10.0.4",
-        "memoize-one": "^4.0.0",
+        "@babel/runtime": "^7.4.4",
+        "@emotion/cache": "^10.0.9",
+        "@emotion/core": "^10.0.9",
+        "@emotion/css": "^10.0.9",
+        "memoize-one": "^5.0.0",
         "prop-types": "^15.6.0",
-        "raf": "^3.4.0",
-        "react-input-autosize": "^2.2.1",
-        "react-transition-group": "^2.2.1"
+        "react-input-autosize": "^2.2.2",
+        "react-transition-group": "^4.3.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "csstype": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
+          "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
+        },
+        "dom-helpers": {
+          "version": "5.1.4",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.4.tgz",
+          "integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
+          "requires": {
+            "@babel/runtime": "^7.8.7",
+            "csstype": "^2.6.7"
+          }
+        },
+        "react-transition-group": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+          "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+          "requires": {
+            "@babel/runtime": "^7.5.5",
+            "dom-helpers": "^5.0.1",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
       }
     },
     "react-syntax-highlighter": {
@@ -28697,8 +28796,7 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -28899,8 +28997,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "react-dropzone": "^4.2.11",
     "react-modal": "^3.8.1",
     "react-popper": "^1.3.3",
-    "react-select": "^2.2.0",
+    "react-select": "^3.1.0",
     "react-transition-group": "~2.3.1"
   },
   "engines": {

--- a/packages/Form/Input/select-multi/package-lock.json
+++ b/packages/Form/Input/select-multi/package-lock.json
@@ -1,115 +1,302 @@
 {
   "name": "@axa-fr/react-toolkit-form-input-select-multi",
-  "version": "1.3.10",
+  "version": "1.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/runtime": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
-      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+    "@babel/code-frame": {
+      "version": "7.10.1",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@babel/code-frame/-/code-frame-7.10.1.tgz",
+      "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
       "requires": {
-        "regenerator-runtime": "^0.12.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
-        }
+        "@babel/highlight": "^7.10.1"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.10.1",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
+      "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
+      "requires": {
+        "@babel/types": "^7.10.1"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.1",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+    },
+    "@babel/highlight": {
+      "version": "7.10.1",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@babel/highlight/-/highlight-7.10.1.tgz",
+      "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.1",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.10.2",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@babel/runtime/-/runtime-7.10.2.tgz",
+      "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/types": {
+      "version": "7.10.2",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@babel/types/-/types-7.10.2.tgz",
+      "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.1",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
       }
     },
     "@emotion/cache": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.0.tgz",
-      "integrity": "sha512-1/sT6GNyvWmxCtJek8ZDV+b+a+NMDx8/61UTnnF3rqrTY7bLTjw+fmXO7WgUIH0owuWKxza/J/FfAWC/RU4G7A==",
+      "version": "10.0.29",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
       "requires": {
-        "@emotion/sheet": "0.9.2",
-        "@emotion/stylis": "0.8.3",
-        "@emotion/utils": "0.11.1",
-        "@emotion/weak-memoize": "0.2.2"
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "@emotion/core": {
+      "version": "10.0.28",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@emotion/core/-/core-10.0.28.tgz",
+      "integrity": "sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "requires": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
       }
     },
     "@emotion/hash": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.1.tgz",
-      "integrity": "sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA=="
+      "version": "0.8.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@emotion/memoize": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz",
-      "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg=="
+      "version": "0.7.4",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "@emotion/serialize": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.3.tgz",
-      "integrity": "sha512-6Q+XH/7kMdHwtylwZvdkOVMydaGZ989axQ56NF7urTR7eiDMLGun//pFUy31ha6QR4C6JB+KJVhZ3AEAJm9Z1g==",
+      "version": "0.11.16",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
       "requires": {
-        "@emotion/hash": "0.7.1",
-        "@emotion/memoize": "0.7.1",
-        "@emotion/unitless": "0.7.3",
-        "@emotion/utils": "0.11.1",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
         "csstype": "^2.5.7"
       }
     },
     "@emotion/sheet": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.2.tgz",
-      "integrity": "sha512-pVBLzIbC/QCHDKJF2E82V2H/W/B004mDFQZiyo/MSR+VC4pV5JLG0TF/zgQDFvP3fZL/5RTPGEmXlYJBMUuJ+A=="
+      "version": "0.9.4",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
     },
     "@emotion/stylis": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.3.tgz",
-      "integrity": "sha512-M3nMfJ6ndJMYloSIbYEBq6G3eqoYD41BpDOxreE8j0cb4fzz/5qvmqU9Mb2hzsXcCnIlGlWhS03PCzVGvTAe0Q=="
+      "version": "0.8.5",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
     },
     "@emotion/unitless": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
-      "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
+      "version": "0.7.5",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@emotion/utils": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.1.tgz",
-      "integrity": "sha512-8M3VN0hetwhsJ8dH8VkVy7xo5/1VoBsDOk/T4SJOeXwTO1c4uIqVNx2qyecLFnnUWD5vvUqHQ1gASSeUN6zcTg=="
+      "version": "0.11.3",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
     },
     "@emotion/weak-memoize": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz",
-      "integrity": "sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA=="
+      "version": "0.2.5",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
-    "create-emotion": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.5.tgz",
-      "integrity": "sha512-MIOSeFiMtPrAULEtd2GFYGZEzeN2xnCFoiHrjvUYjxruYCJfGqUOBmh4YEN1yU+Ww5yXr+DIZibFl7FEOP57iA==",
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "@emotion/cache": "10.0.0",
-        "@emotion/serialize": "^0.11.3",
-        "@emotion/sheet": "0.9.2",
-        "@emotion/utils": "0.11.1"
+        "color-convert": "^1.9.0"
+      }
+    },
+    "babel-plugin-emotion": {
+      "version": "10.0.33",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      }
+    },
+    "babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "cosmiconfig": {
+      "version": "6.0.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.7.2"
       }
     },
     "csstype": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.0.tgz",
-      "integrity": "sha512-by8hi8BlLbowQq0qtkx54d9aN73R9oUW20HISpka5kmgsR9F7nnxgfsemuR2sdCKZh+CDNf5egW9UZMm4mgJRg=="
+      "version": "2.6.10",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/csstype/-/csstype-2.6.10.tgz",
+      "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
     },
     "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "version": "5.1.4",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/dom-helpers/-/dom-helpers-5.1.4.tgz",
+      "integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^2.6.7"
       }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -120,19 +307,43 @@
       }
     },
     "memoize-one": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
-      "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+      "version": "5.1.1",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.0.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/parse-json/-/parse-json-5.0.0.tgz",
+      "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "prop-types": {
       "version": "15.6.2",
@@ -143,51 +354,85 @@
         "object-assign": "^4.1.1"
       }
     },
-    "raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "requires": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "react-input-autosize": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.1.tgz",
-      "integrity": "sha512-3+K4CD13iE4lQQ2WlF8PuV5htfmTRLH6MDnfndHM6LuBRszuXnuyIfE7nhSKt8AzRBZ50bu0sAhkNMeS5pxQQA==",
+      "version": "2.2.2",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
+      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
       "requires": {
         "prop-types": "^15.5.8"
       }
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-select": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-2.2.0.tgz",
-      "integrity": "sha512-FOnsm/zrJ2pZvYsEfs58Xvru0SHL1jXAZTCFTWcOxmQSnRKgYuXUDFdpDiET90GLtJEF+t6BaZeD43bUH6/NZQ==",
+      "version": "3.1.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/react-select/-/react-select-3.1.0.tgz",
+      "integrity": "sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==",
       "requires": {
-        "classnames": "^2.2.5",
-        "create-emotion": "^10.0.4",
-        "memoize-one": "^4.0.0",
+        "@babel/runtime": "^7.4.4",
+        "@emotion/cache": "^10.0.9",
+        "@emotion/core": "^10.0.9",
+        "@emotion/css": "^10.0.9",
+        "memoize-one": "^5.0.0",
         "prop-types": "^15.6.0",
-        "raf": "^3.4.0",
-        "react-input-autosize": "^2.2.1",
-        "react-transition-group": "^2.2.1"
+        "react-input-autosize": "^2.2.2",
+        "react-transition-group": "^4.3.0"
       }
     },
     "react-transition-group": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.2.tgz",
-      "integrity": "sha512-vwHP++S+f6KL7rg8V1mfs62+MBKtbMeZDR8KiNmD7v98Gs3UPGsDZDahPJH2PVprFW5YHJfh6cbNim3zPndaSQ==",
+      "version": "4.4.1",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
       "requires": {
-        "dom-helpers": "^3.3.1",
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
+        "prop-types": "^15.6.2"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://afa-nrepo.azure-paas.intraxa/repository/npmjs-group/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     }
   }
 }

--- a/packages/Form/Input/select-multi/package.json
+++ b/packages/Form/Input/select-multi/package.json
@@ -15,7 +15,7 @@
     "@axa-fr/react-toolkit-core": "^1.3.12",
     "@axa-fr/react-toolkit-form-core": "^1.3.12",
     "prop-types": "^15.5.10",
-    "react-select": "^2.2.0"
+    "react-select": "^3.1.0"
   },
   "license": "MIT",
   "publishConfig": {

--- a/packages/Form/Input/select-multi/src/MultiSelect.js
+++ b/packages/Form/Input/select-multi/src/MultiSelect.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactSelect from 'react-select';
+import ReactSelectAsync from 'react-select/async';
 
 import {
   Input,
@@ -29,9 +30,9 @@ const MultiSelect = props => {
     noResultsText,
     ...otherProps
   } = props;
-  
+
   const isDisabled = disabled || readOnly;
-  const SelectComponent = loadOptions ? ReactSelect.Async : ReactSelect;
+  const SelectComponent = loadOptions ? ReactSelectAsync : ReactSelect;
 
   if (values != null) {
     const newValues = options.reduce((acc, opt) => {

--- a/packages/Form/Input/select-multi/src/__snapshots__/MultiSelect.spec.js.snap
+++ b/packages/Form/Input/select-multi/src/__snapshots__/MultiSelect.spec.js.snap
@@ -2,19 +2,19 @@
 
 exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
 <div
-  className="css-10nd86i react-select"
+  className="react-select css-2b097c-container"
   onKeyDown={[Function]}
 >
   <div
-    className="css-vj8t7z"
+    className=" css-yk16xz-control"
     onMouseDown={[Function]}
     onTouchEnd={[Function]}
   >
     <div
-      className="css-1hwfws3"
+      className=" css-g1d714-ValueContainer"
     >
       <div
-        className="css-xwjg1b"
+        className="css-1rhbuit-multiValue"
       >
         <div
           className="css-12jo7m5"
@@ -22,14 +22,14 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
           For fun
         </div>
         <div
-          className="css-1alnv5e"
+          className="css-xb97g8"
           onClick={[Function]}
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
         >
           <svg
             aria-hidden="true"
-            className="css-19bqh2r"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={14}
             viewBox="0 0 20 20"
@@ -42,7 +42,7 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
         </div>
       </div>
       <div
-        className="css-xwjg1b"
+        className="css-1rhbuit-multiValue"
       >
         <div
           className="css-12jo7m5"
@@ -50,14 +50,14 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
           For drink
         </div>
         <div
-          className="css-1alnv5e"
+          className="css-xb97g8"
           onClick={[Function]}
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
         >
           <svg
             aria-hidden="true"
-            className="css-19bqh2r"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={14}
             viewBox="0 0 20 20"
@@ -70,7 +70,7 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
         </div>
       </div>
       <div
-        className="css-1g6gooi"
+        className="css-b8ldur-Input"
       >
         <div
           className=""
@@ -98,6 +98,7 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
                 "boxSizing": "content-box",
                 "color": "inherit",
                 "fontSize": "inherit",
+                "label": "input",
                 "opacity": 1,
                 "outline": 0,
                 "padding": 0,
@@ -127,17 +128,17 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
       </div>
     </div>
     <div
-      className="css-1wy0on6"
+      className=" css-1hb7zxy-IndicatorsContainer"
     >
       <div
         aria-hidden="true"
-        className="css-1ep9fjw"
+        className=" css-tlfecz-indicatorContainer"
         onMouseDown={[Function]}
         onTouchEnd={[Function]}
       >
         <svg
           aria-hidden="true"
-          className="css-19bqh2r"
+          className="css-6q0nyr-Svg"
           focusable="false"
           height={20}
           viewBox="0 0 20 20"
@@ -149,17 +150,17 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
         </svg>
       </div>
       <span
-        className="css-d8oujb"
+        className=" css-1okebmr-indicatorSeparator"
       />
       <div
         aria-hidden="true"
-        className="css-1ep9fjw"
+        className=" css-tlfecz-indicatorContainer"
         onMouseDown={[Function]}
         onTouchEnd={[Function]}
       >
         <svg
           aria-hidden="true"
-          className="css-19bqh2r"
+          className="css-6q0nyr-Svg"
           focusable="false"
           height={20}
           viewBox="0 0 20 20"

--- a/packages/Form/Input/select-multi/src/__snapshots__/MultiSelectInput.spec.js.snap
+++ b/packages/Form/Input/select-multi/src/__snapshots__/MultiSelectInput.spec.js.snap
@@ -2,19 +2,19 @@
 
 exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
 <div
-  className="css-10nd86i react-select"
+  className="react-select css-2b097c-container"
   onKeyDown={[Function]}
 >
   <div
-    className="css-vj8t7z"
+    className=" css-yk16xz-control"
     onMouseDown={[Function]}
     onTouchEnd={[Function]}
   >
     <div
-      className="css-1hwfws3"
+      className=" css-g1d714-ValueContainer"
     >
       <div
-        className="css-xwjg1b"
+        className="css-1rhbuit-multiValue"
       >
         <div
           className="css-12jo7m5"
@@ -22,14 +22,14 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
           For fun
         </div>
         <div
-          className="css-1alnv5e"
+          className="css-xb97g8"
           onClick={[Function]}
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
         >
           <svg
             aria-hidden="true"
-            className="css-19bqh2r"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={14}
             viewBox="0 0 20 20"
@@ -42,7 +42,7 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
         </div>
       </div>
       <div
-        className="css-xwjg1b"
+        className="css-1rhbuit-multiValue"
       >
         <div
           className="css-12jo7m5"
@@ -50,14 +50,14 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
           For drink
         </div>
         <div
-          className="css-1alnv5e"
+          className="css-xb97g8"
           onClick={[Function]}
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
         >
           <svg
             aria-hidden="true"
-            className="css-19bqh2r"
+            className="css-6q0nyr-Svg"
             focusable="false"
             height={14}
             viewBox="0 0 20 20"
@@ -70,7 +70,7 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
         </div>
       </div>
       <div
-        className="css-1g6gooi"
+        className="css-b8ldur-Input"
       >
         <div
           className=""
@@ -98,6 +98,7 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
                 "boxSizing": "content-box",
                 "color": "inherit",
                 "fontSize": "inherit",
+                "label": "input",
                 "opacity": 1,
                 "outline": 0,
                 "padding": 0,
@@ -127,17 +128,17 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
       </div>
     </div>
     <div
-      className="css-1wy0on6"
+      className=" css-1hb7zxy-IndicatorsContainer"
     >
       <div
         aria-hidden="true"
-        className="css-1ep9fjw"
+        className=" css-tlfecz-indicatorContainer"
         onMouseDown={[Function]}
         onTouchEnd={[Function]}
       >
         <svg
           aria-hidden="true"
-          className="css-19bqh2r"
+          className="css-6q0nyr-Svg"
           focusable="false"
           height={20}
           viewBox="0 0 20 20"
@@ -149,17 +150,17 @@ exports[`<MultiSelect> renders MultiSelect correctly 1`] = `
         </svg>
       </div>
       <span
-        className="css-d8oujb"
+        className=" css-1okebmr-indicatorSeparator"
       />
       <div
         aria-hidden="true"
-        className="css-1ep9fjw"
+        className=" css-tlfecz-indicatorContainer"
         onMouseDown={[Function]}
         onTouchEnd={[Function]}
       >
         <svg
           aria-hidden="true"
-          className="css-19bqh2r"
+          className="css-6q0nyr-Svg"
           focusable="false"
           height={20}
           viewBox="0 0 20 20"
@@ -208,20 +209,20 @@ exports[`<MultiSelect> renders MultiSelectInput correctly 1`] = `
       className="af-form__select"
     >
       <div
-        className="css-10nd86i react-select"
+        className="react-select css-2b097c-container"
         id="multiselectid"
         onKeyDown={[Function]}
       >
         <div
-          className="css-vj8t7z"
+          className=" css-yk16xz-control"
           onMouseDown={[Function]}
           onTouchEnd={[Function]}
         >
           <div
-            className="css-1hwfws3"
+            className=" css-g1d714-ValueContainer"
           >
             <div
-              className="css-xwjg1b"
+              className="css-1rhbuit-multiValue"
             >
               <div
                 className="css-12jo7m5"
@@ -229,14 +230,14 @@ exports[`<MultiSelect> renders MultiSelectInput correctly 1`] = `
                 For fun
               </div>
               <div
-                className="css-1alnv5e"
+                className="css-xb97g8"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onTouchEnd={[Function]}
               >
                 <svg
                   aria-hidden="true"
-                  className="css-19bqh2r"
+                  className="css-6q0nyr-Svg"
                   focusable="false"
                   height={14}
                   viewBox="0 0 20 20"
@@ -249,7 +250,7 @@ exports[`<MultiSelect> renders MultiSelectInput correctly 1`] = `
               </div>
             </div>
             <div
-              className="css-xwjg1b"
+              className="css-1rhbuit-multiValue"
             >
               <div
                 className="css-12jo7m5"
@@ -257,14 +258,14 @@ exports[`<MultiSelect> renders MultiSelectInput correctly 1`] = `
                 For drink
               </div>
               <div
-                className="css-1alnv5e"
+                className="css-xb97g8"
                 onClick={[Function]}
                 onMouseDown={[Function]}
                 onTouchEnd={[Function]}
               >
                 <svg
                   aria-hidden="true"
-                  className="css-19bqh2r"
+                  className="css-6q0nyr-Svg"
                   focusable="false"
                   height={14}
                   viewBox="0 0 20 20"
@@ -277,7 +278,7 @@ exports[`<MultiSelect> renders MultiSelectInput correctly 1`] = `
               </div>
             </div>
             <div
-              className="css-1g6gooi"
+              className="css-b8ldur-Input"
             >
               <div
                 className=""
@@ -305,6 +306,7 @@ exports[`<MultiSelect> renders MultiSelectInput correctly 1`] = `
                       "boxSizing": "content-box",
                       "color": "inherit",
                       "fontSize": "inherit",
+                      "label": "input",
                       "opacity": 1,
                       "outline": 0,
                       "padding": 0,
@@ -334,17 +336,17 @@ exports[`<MultiSelect> renders MultiSelectInput correctly 1`] = `
             </div>
           </div>
           <div
-            className="css-1wy0on6"
+            className=" css-1hb7zxy-IndicatorsContainer"
           >
             <div
               aria-hidden="true"
-              className="css-1ep9fjw"
+              className=" css-tlfecz-indicatorContainer"
               onMouseDown={[Function]}
               onTouchEnd={[Function]}
             >
               <svg
                 aria-hidden="true"
-                className="css-19bqh2r"
+                className="css-6q0nyr-Svg"
                 focusable="false"
                 height={20}
                 viewBox="0 0 20 20"
@@ -356,17 +358,17 @@ exports[`<MultiSelect> renders MultiSelectInput correctly 1`] = `
               </svg>
             </div>
             <span
-              className="css-d8oujb"
+              className=" css-1okebmr-indicatorSeparator"
             />
             <div
               aria-hidden="true"
-              className="css-1ep9fjw"
+              className=" css-tlfecz-indicatorContainer"
               onMouseDown={[Function]}
               onTouchEnd={[Function]}
             >
               <svg
                 aria-hidden="true"
-                className="css-19bqh2r"
+                className="css-6q0nyr-Svg"
                 focusable="false"
                 height={20}
                 viewBox="0 0 20 20"

--- a/storybook/storybook/package.json
+++ b/storybook/storybook/package.json
@@ -88,7 +88,7 @@
     "react-dropzone": "^4.2.11",
     "react-modal": "^3.8.1",
     "react-popper": "^0.8.3",
-    "react-select": "^2.2.0",
+    "react-select": "^3.1.0",
     "react-transition-group": "~2.3.1",
     "webpack": "^4.28.3",
     "webpack-dev-server": "^3.1.14"


### PR DESCRIPTION
Bump react-select to latest version.

I followed the [migration guide](https://github.com/JedWatson/react-select/issues/3585).
The only change for us is the new import for the async react-select component.

@guillaume-chervet @samuel-gomez @youf-olivier 