### PR TITLE
fix(title): Fix burger menu in plain display

### DIFF
--- a/packages/Layout/header/src/Title/Title.js
+++ b/packages/Layout/header/src/Title/Title.js
@@ -38,16 +38,20 @@ const Title = props => {
   return (
     <div className={componentClassName}>
       <div className={`container ${defaultClassName}__wrapper`}>
-        <ToggleButton idControl="mainmenu">
-          <Action
-            className="btn af-btn--circle af-title-bar__mobile-menu"
-            classModifier={null}
-            id="togglemenu"
-            icon="menu-hamburger"
-            title="Toggle menu"
-            onClick={toggleMenu}
-          />
-        </ToggleButton>
+        {!!toggleMenu && (
+          <div className="burger-container">
+            <ToggleButton idControl="mainmenu">
+              <Action
+                className="btn af-title-bar__mobile-menu af-btn--circle"
+                classModifier={null}
+                id="togglemenu"
+                icon="menu-hamburger"
+                title="Toggle menu"
+                onClick={toggleMenu}
+              />
+            </ToggleButton>
+          </div>
+        )}
         <h1 className={`${defaultClassName}__title`}>
           {title}
           {subtitle && (

--- a/packages/Layout/header/src/Title/Title.spec.js
+++ b/packages/Layout/header/src/Title/Title.spec.js
@@ -9,9 +9,16 @@ describe('<Title>', () => {
         <Title
           title="Toolkit Axa"
           subtitle="Info complémentaire"
-          onClick={() => null}
+          toggleMenu={() => null}
         />
       )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders Title correctly without menu', () => {
+    const tree = renderer
+      .create(<Title title="Toolkit Axa" subtitle="Info complémentaire" />)
       .toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/Layout/header/src/Title/__snapshots__/Title.spec.js.snap
+++ b/packages/Layout/header/src/Title/__snapshots__/Title.spec.js.snap
@@ -7,21 +7,46 @@ exports[`<Title> renders Title correctly 1`] = `
   <div
     className="container af-title-bar__wrapper"
   >
-    <a
-      aria-controls="mainmenu"
-      aria-haspopup={true}
-      className="btn af-btn--circle af-title-bar__mobile-menu"
-      href="#"
-      id="togglemenu"
-      onClick={[Function]}
-      role="button"
-      tabIndex={0}
-      title="Toggle menu"
+    <div
+      className="burger-container"
     >
-      <i
-        className="glyphicon glyphicon-menu-hamburger"
-      />
-    </a>
+      <a
+        aria-controls="mainmenu"
+        aria-haspopup={true}
+        className="btn af-title-bar__mobile-menu af-btn--circle"
+        href="#"
+        id="togglemenu"
+        onClick={[Function]}
+        role="button"
+        tabIndex={0}
+        title="Toggle menu"
+      >
+        <i
+          className="glyphicon glyphicon-menu-hamburger"
+        />
+      </a>
+    </div>
+    <h1
+      className="af-title-bar__title"
+    >
+      Toolkit Axa
+      <small
+        className="af-title-bar__subtitle"
+      >
+        Info complémentaire
+      </small>
+    </h1>
+  </div>
+</div>
+`;
+
+exports[`<Title> renders Title correctly without menu 1`] = `
+<div
+  className="af-title-bar"
+>
+  <div
+    className="container af-title-bar__wrapper"
+  >
     <h1
       className="af-title-bar__title"
     >

--- a/packages/Layout/header/src/Title/title-bar.scss
+++ b/packages/Layout/header/src/Title/title-bar.scss
@@ -88,6 +88,10 @@
       width: 100%;
     }
   }
+
+  .burger-container {
+    display: none;
+  }
 }
 @include media-breakpoint-up(md) {
   .af-title-bar {
@@ -100,10 +104,6 @@
 
     &__title {
       font-size: 1.5rem;
-    }
-
-    &__mobile-menu {
-      display: none;
     }
   }
 }

--- a/storybook/storybook/src/packages/Layout/header/src/Title/src/Title.stories.js
+++ b/storybook/storybook/src/packages/Layout/header/src/Title/src/Title.stories.js
@@ -24,12 +24,12 @@ const TitleStory = () => (
   <Title
     title="Toolkit Axa"
     subtitle="Info complémentaire"
-    onClick={action('onToggle')}
+    toggleMenu={action('onToggle')}
   />
 );
 
 const TitleComplexStory = () => (
-  <Title title="Toolkit Axa" subtitle="Sous titre" onClick={action('onToggle')}>
+  <Title title="Toolkit Axa" subtitle="Sous titre" toggleMenu={action('onToggle')}>
     <div className="af-title-bar__actions">
       <a className="af-title-bar__link" href="#lien" title="lien titlebar">
         lien titlebar


### PR DESCRIPTION
Before : 

![image](https://user-images.githubusercontent.com/40664502/84988047-950eff00-b141-11ea-9b98-29cc7b9161f3.png)

After

![image](https://user-images.githubusercontent.com/40664502/84988093-a8ba6580-b141-11ea-9dde-2bf37761575a.png)

We use the burger menu only if : 
- We are in small display
- The togglemenu function is passed in props


https://axaguildev.github.io/react-toolkit/latest/design/molecules/title-bar/
