### PR TITLE
feat(popover): fix a11y for popover

### DIFF
--- a/packages/help/src/__snapshots__/Help.spec.js.snap
+++ b/packages/help/src/__snapshots__/Help.spec.js.snap
@@ -1,10 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Help> Render Should render Help component 1`] = `
-<span
+<button
+  className="af-popover__wrapper"
   onClick={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
+  type="button"
 >
   <div
     className="af-popover__container"
@@ -25,5 +27,5 @@ exports[`<Help> Render Should render Help component 1`] = `
       </button>
     </div>
   </div>
-</span>
+</button>
 `;

--- a/packages/popover/src/Popover.js
+++ b/packages/popover/src/Popover.js
@@ -40,7 +40,7 @@ export const PopoverClick = props => {
     };
   });
 
-  const click = (event) => {
+  const click = event => {
     setOpen(!isOpen && isHover);
     event.stopPropagation();
   };
@@ -54,7 +54,12 @@ export const PopoverClick = props => {
   };
 
   return (
-    <span onMouseEnter={enter} onMouseLeave={leave} onClick={click}>
+    <button
+      className="af-popover__wrapper"
+      type="button"
+      onMouseEnter={enter}
+      onMouseLeave={leave}
+      onClick={click}>
       <PopoverBase
         isOpen={isOpen}
         placement={placement}
@@ -62,7 +67,7 @@ export const PopoverClick = props => {
         classModifier={classModifier}>
         {children}
       </PopoverBase>
-    </span>
+    </button>
   );
 };
 

--- a/packages/popover/src/popover.scss
+++ b/packages/popover/src/popover.scss
@@ -5,6 +5,12 @@ $arrow-offset: -4px;
 $padding-popover: 0.5rem;
 
 .af-popover {
+  &__wrapper {
+    background: inherit;
+    border: 0;
+    padding: 0;
+  }
+
   &__container {
     display: inline-block;
 


### PR DESCRIPTION
Fix a11y issue on the popover when "click" mode:

- Visible, non-interactive elements with click handlers must have at least one keyboard listener jsx-a11y/click-events-have-key-events 
- Static HTML elements with event handlers require a role jsx-a11y/no-static-element-interactions