### PR TITLE
feat(form-input-choice): use the id instead of generating a new one

### DIFF
--- a/packages/Form/Input/choice/src/Choice.spec.js
+++ b/packages/Form/Input/choice/src/Choice.spec.js
@@ -3,14 +3,43 @@ import renderer from 'react-test-renderer';
 import ChoiceInput from './ChoiceInput';
 
 describe('<ChoiceInput>', () => {
-  it('renders ChoiceInput correctly', () => {
+  it('renders ChoiceInput correctly when passing options without ID', () => {
     const tree = renderer
       .create(
         <ChoiceInput
-          label="Image *"
-          id="iddateinput"
-          name="placeImage"
-          options={[{ id: 'iddateinput', value: 'sample' }]}
+          label="Some label"
+          id="xxx"
+          name="xxx"
+          options={[{ label: 'Yes', value: true }, { label: 'No', value: false }]}
+          onChange={() => {}}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders ChoiceInput correctly when passing options with ID', () => {
+    const tree = renderer
+      .create(
+        <ChoiceInput
+          label="Some label"
+          id="xxx"
+          name="xxx"
+          options={[{ label: 'Yes', value: true, id: 'xxx_Yes' }, { label: 'No', value: false, id: 'xxx_No' }]}
+          onChange={() => {}}
+        />
+      )
+      .toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders ChoiceInput correctly with default options', () => {
+    const tree = renderer
+      .create(
+        <ChoiceInput
+          label="Some label"
+          id="xxx"
+          name="xxx"
           onChange={() => {}}
         />
       )

--- a/packages/Form/Input/choice/src/ChoiceInput.js
+++ b/packages/Form/Input/choice/src/ChoiceInput.js
@@ -12,9 +12,12 @@ const propTypes = {
 const defaultProps = {
   ...Constants.defaultProps,
   value: null,
+  options: [
+    { label: 'Oui', value: true },
+    { label: 'Non', value: false },
+  ],
 };
 
-const options = [{ label: 'Oui', value: true }, { label: 'Non', value: false }];
 const ChoiceInput = props => {
   const {
     mode,
@@ -33,13 +36,25 @@ const ChoiceInput = props => {
     onChange,
     readOnly,
     disabled,
+    options,
     ...otherProps
   } = props;
   if (!isVisible) {
     return null;
   }
 
-  const newOptions = InputManager.getOptionsWithId(options);
+  let newOptions;
+  if (id) {
+    newOptions = options.map((option, index) => {
+      if (option.id) {
+        return option;
+      }
+
+      return { ...option, id: `${id}_${index}` };
+    });
+  }
+  newOptions = InputManager.getOptionsWithId(newOptions);
+
   const firstId = InputManager.getFirstId(newOptions);
   return (
     <Field

--- a/packages/Form/Input/choice/src/__snapshots__/Choice.spec.js.snap
+++ b/packages/Form/Input/choice/src/__snapshots__/Choice.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ChoiceInput> renders ChoiceInput correctly 1`] = `
+exports[`<ChoiceInput> renders ChoiceInput correctly when passing options with ID 1`] = `
 <div
   className="row af-form__group"
 >
@@ -11,7 +11,7 @@ exports[`<ChoiceInput> renders ChoiceInput correctly 1`] = `
       className="af-form__group-label"
       htmlFor=""
     >
-      Image *
+      Some label
     </label>
   </div>
   <div
@@ -26,23 +26,217 @@ exports[`<ChoiceInput> renders ChoiceInput correctly 1`] = `
         className="af-form__input-radio"
         componentClassName="af-form__radio-custom"
         disabled={false}
-        id="iddateinput"
-        name="placeImage"
+        id="xxx_Yes"
+        name="xxx"
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
         readOnly={false}
         tabIndex={null}
         type="radio"
-        value="sample"
+        value="true"
       />
       <label
         className="af-form__label"
-        htmlFor="iddateinput"
+        htmlFor="xxx_Yes"
       >
         <span
           className="af-form__description"
-        />
+        >
+          Yes
+        </span>
+      </label>
+    </div>
+    <div
+      className="af-form__radio-custom"
+    >
+      <input
+        autoFocus={null}
+        checked={false}
+        className="af-form__input-radio"
+        componentClassName="af-form__radio-custom"
+        disabled={false}
+        id="xxx_No"
+        name="xxx"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        readOnly={false}
+        tabIndex={null}
+        type="radio"
+        value="false"
+      />
+      <label
+        className="af-form__label"
+        htmlFor="xxx_No"
+      >
+        <span
+          className="af-form__description"
+        >
+          No
+        </span>
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<ChoiceInput> renders ChoiceInput correctly when passing options without ID 1`] = `
+<div
+  className="row af-form__group"
+>
+  <div
+    className="col-md-2"
+  >
+    <label
+      className="af-form__group-label"
+      htmlFor=""
+    >
+      Some label
+    </label>
+  </div>
+  <div
+    className="col-md-10"
+  >
+    <div
+      className="af-form__radio-custom"
+    >
+      <input
+        autoFocus={null}
+        checked={false}
+        className="af-form__input-radio"
+        componentClassName="af-form__radio-custom"
+        disabled={false}
+        id="xxx_0"
+        name="xxx"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        readOnly={false}
+        tabIndex={null}
+        type="radio"
+        value="true"
+      />
+      <label
+        className="af-form__label"
+        htmlFor="xxx_0"
+      >
+        <span
+          className="af-form__description"
+        >
+          Yes
+        </span>
+      </label>
+    </div>
+    <div
+      className="af-form__radio-custom"
+    >
+      <input
+        autoFocus={null}
+        checked={false}
+        className="af-form__input-radio"
+        componentClassName="af-form__radio-custom"
+        disabled={false}
+        id="xxx_1"
+        name="xxx"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        readOnly={false}
+        tabIndex={null}
+        type="radio"
+        value="false"
+      />
+      <label
+        className="af-form__label"
+        htmlFor="xxx_1"
+      >
+        <span
+          className="af-form__description"
+        >
+          No
+        </span>
+      </label>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<ChoiceInput> renders ChoiceInput correctly with default options 1`] = `
+<div
+  className="row af-form__group"
+>
+  <div
+    className="col-md-2"
+  >
+    <label
+      className="af-form__group-label"
+      htmlFor=""
+    >
+      Some label
+    </label>
+  </div>
+  <div
+    className="col-md-10"
+  >
+    <div
+      className="af-form__radio-custom"
+    >
+      <input
+        autoFocus={null}
+        checked={false}
+        className="af-form__input-radio"
+        componentClassName="af-form__radio-custom"
+        disabled={false}
+        id="xxx_0"
+        name="xxx"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        readOnly={false}
+        tabIndex={null}
+        type="radio"
+        value="true"
+      />
+      <label
+        className="af-form__label"
+        htmlFor="xxx_0"
+      >
+        <span
+          className="af-form__description"
+        >
+          Oui
+        </span>
+      </label>
+    </div>
+    <div
+      className="af-form__radio-custom"
+    >
+      <input
+        autoFocus={null}
+        checked={false}
+        className="af-form__input-radio"
+        componentClassName="af-form__radio-custom"
+        disabled={false}
+        id="xxx_1"
+        name="xxx"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        readOnly={false}
+        tabIndex={null}
+        type="radio"
+        value="false"
+      />
+      <label
+        className="af-form__label"
+        htmlFor="xxx_1"
+      >
+        <span
+          className="af-form__description"
+        >
+          Non
+        </span>
       </label>
     </div>
   </div>


### PR DESCRIPTION
When the ChoiceInput options don't have an id, use the id that we pass to create one (concatenate it with the index) instead of always generating a new one.

It allows to use snapshots with this component.

Fixes #616 