### PR TITLE
feat(layout-footer): use current year as default in copyright

### DIFF
--- a/packages/Layout/footer/src/FooterCore.tsx
+++ b/packages/Layout/footer/src/FooterCore.tsx
@@ -15,9 +15,8 @@ interface FooterCoreComponentProps {
   alt?: string;
   className?: string;
 }
-
 const defaultProps: Partial<FooterCoreComponentProps> = {
-  children: '@ 2018 AXA Tous droits réservés',
+  children: `© ${new Date().getFullYear()} AXA Tous droits réservés`,
   href: 'https://www.axa.fr/',
   title: 'Site Axa',
   icon: 'assets/logo-axa.svg',
@@ -33,17 +32,18 @@ const FooterCoreRaw: React.SFC<FooterCoreComponentProps> = ({
   children,
 }) => (
   <footer className={className}>
-    <div className='container-fluid container'>
-      <a className='af-logo' href={href} title={title} target='blank'>
-        <img className='af-logo__brand' src={icon} alt={alt} />
+    <div className="container-fluid container">
+      <a className="af-logo" href={href} title={title} target="blank">
+        <img className="af-logo__brand" src={icon} alt={alt} />
       </a>
-      <div className='af-footer-content'>{children}</div>
+      <div className="af-footer-content">{children}</div>
     </div>
   </footer>
 );
 FooterCoreRaw.defaultProps = defaultProps;
 
-export type FooterCoreProps = FooterCoreComponentProps & WithClassModifierOptions;
+export type FooterCoreProps = FooterCoreComponentProps &
+  WithClassModifierOptions;
 
 const enhance = compose<FooterCoreComponentProps, FooterCoreProps>(
   withClassDefault(DEFAULT_CLASSNAME),


### PR DESCRIPTION
Use the current year as default value in the copyright of the footer instead of a fixed value (2018).
There is no need to override it by default.

Fixes #601 