### PR TITLE
fix(popover): popover prevents click action on the page

### DIFF
--- a/packages/help/src/__snapshots__/Help.spec.js.snap
+++ b/packages/help/src/__snapshots__/Help.spec.js.snap
@@ -1,12 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Help> Render Should render Help component 1`] = `
-<button
+<div
   className="af-popover__wrapper"
   onClick={[Function]}
+  onKeyDown={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
-  type="button"
+  role="button"
+  tabIndex="0"
 >
   <div
     className="af-popover__container"
@@ -27,5 +29,5 @@ exports[`<Help> Render Should render Help component 1`] = `
       </button>
     </div>
   </div>
-</button>
+</div>
 `;

--- a/packages/help/src/__snapshots__/Help.spec.js.snap
+++ b/packages/help/src/__snapshots__/Help.spec.js.snap
@@ -1,14 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Help> Render Should render Help component 1`] = `
-<div
+<button
   className="af-popover__wrapper"
   onClick={[Function]}
-  onKeyDown={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
-  role="button"
-  tabIndex="0"
+  type="button"
 >
   <div
     className="af-popover__container"
@@ -29,5 +27,5 @@ exports[`<Help> Render Should render Help component 1`] = `
       </button>
     </div>
   </div>
-</div>
+</button>
 `;

--- a/packages/popover/src/Popover.js
+++ b/packages/popover/src/Popover.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Constants } from '@axa-fr/react-toolkit-core';
 import PopoverBase from './PopoverBase';
@@ -30,48 +30,65 @@ export const PopoverClick = props => {
   const wrapperRef = useRef(null);
   const [isOpen, setOpen] = useState(false);
   const [isHover, setHover] = useState(false);
+  const [isPopoverHover, setPopoverHover] = useState(false);
 
-  useEffect(() => {
-    const handleClickOutside = event => {
-      if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
-        setOpen(false);
-      }
-    };
-
-    document.addEventListener('click', handleClickOutside);
-    return () => {
+  const handleClickOutside = event => {
+    if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
+      setOpen(false);
       document.removeEventListener('click', handleClickOutside);
-    };
-  }, [wrapperRef]);
-
-  const click = () => {
-    setOpen(!isOpen && isHover);
+    }
   };
 
-  const enter = () => {
+  const handleClick = event => {
+    if (isPopoverHover) {
+      event.stopPropagation();
+      return;
+    }
+
+    const shouldOpen = !isOpen && isHover;
+    setOpen(shouldOpen);
+
+    if (shouldOpen) {
+      document.addEventListener('click', handleClickOutside);
+    }
+  };
+
+  const handleMouseEnter = () => {
     setHover(true);
   };
 
-  const leave = () => {
+  const handleMouseLeave = () => {
     setHover(false);
   };
 
+  const handleMouseEnterPopover = () => {
+    setPopoverHover(true);
+  };
+
+  const handleMouseLeavePopover = () => {
+    setPopoverHover(false);
+  };
+
   return (
-    <button
+    <div
+      role="button"
+      tabIndex="0"
       ref={wrapperRef}
       className="af-popover__wrapper"
-      type="button"
-      onMouseEnter={enter}
-      onMouseLeave={leave}
-      onClick={click}>
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onKeyDown={handleClick}
+      onClick={handleClick}>
       <PopoverBase
+        onMouseEnter={handleMouseEnterPopover}
+        onMouseLeave={handleMouseLeavePopover}
         isOpen={isOpen}
         placement={placement}
         className={className}
         classModifier={classModifier}>
         {children}
       </PopoverBase>
-    </button>
+    </div>
   );
 };
 
@@ -79,16 +96,19 @@ export const PopoverOver = props => {
   const { children, placement, className, classModifier } = props;
   const [isOpen, setOpen] = useState(false);
 
-  const enter = () => {
+  const handleMouseEnter = () => {
     setOpen(true);
   };
 
-  const leave = () => {
+  const handleMouseLeave = () => {
     setOpen(false);
   };
 
   return (
-    <span onMouseEnter={enter} onMouseLeave={leave}>
+    <div
+      className="af-popover__wrapper"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}>
       <PopoverBase
         isOpen={isOpen}
         placement={placement}
@@ -96,7 +116,7 @@ export const PopoverOver = props => {
         classModifier={classModifier}>
         {children}
       </PopoverBase>
-    </span>
+    </div>
   );
 };
 

--- a/packages/popover/src/Popover.js
+++ b/packages/popover/src/Popover.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Constants } from '@axa-fr/react-toolkit-core';
 import PopoverBase from './PopoverBase';
@@ -28,21 +28,25 @@ const defaultProps = {
 export const PopoverClick = props => {
   const { children, placement, className, classModifier } = props;
 
+  const wrapperRef = useRef(null);
   const [isOpen, setOpen] = useState(false);
   const [isHover, setHover] = useState(false);
 
   useEffect(() => {
-    const body = window.document.getElementsByTagName('body')[0];
-    body.addEventListener('click', click);
-
-    return () => {
-      body.removeEventListener('click', click);
+    const handleClickOutside = event => {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
+        setOpen(false);
+      }
     };
-  });
 
-  const click = event => {
+    document.addEventListener('click', handleClickOutside);
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, [wrapperRef]);
+
+  const click = () => {
     setOpen(!isOpen && isHover);
-    event.stopPropagation();
   };
 
   const enter = () => {
@@ -55,6 +59,7 @@ export const PopoverClick = props => {
 
   return (
     <button
+      ref={wrapperRef}
       className="af-popover__wrapper"
       type="button"
       onMouseEnter={enter}

--- a/packages/popover/src/Popover.js
+++ b/packages/popover/src/Popover.js
@@ -7,7 +7,6 @@ import PopoverModes from './PopoverModes';
 
 const propTypes = {
   ...Constants.propTypes,
-  title: PropTypes.string,
   children: PropTypes.any,
   placement: PropTypes.oneOf([
     PopoverPlacements.top,

--- a/packages/popover/src/PopoverBase.js
+++ b/packages/popover/src/PopoverBase.js
@@ -74,7 +74,7 @@ export const AnimatedPopover = props => {
   const componentClassName = ClassManager.getComponentClassName(
     className,
     classModifier,
-    defaultClassName,
+    defaultClassName
   );
 
   const [referenceElement, setReferenceElement] = useState(null);
@@ -82,7 +82,12 @@ export const AnimatedPopover = props => {
   const [arrowElement, setArrowElement] = useState(null);
   const { styles, attributes } = usePopper(referenceElement, popperElement, {
     modifiers: [
-      { name: 'arrow', options: { element: arrowElement } },
+      {
+        name: 'arrow',
+        options: {
+          element: arrowElement,
+        },
+      },
       {
         name: 'offset',
         options: {
@@ -111,9 +116,7 @@ export const AnimatedPopover = props => {
           data-popper-placement={placement}
           className="af-popover__container-pop"
           {...attributes.popper}>
-          <div>
-            {children}
-          </div>
+          <div>{children}</div>
           <div
             ref={setArrowElement}
             style={styles.arrow}

--- a/packages/popover/src/popover.scss
+++ b/packages/popover/src/popover.scss
@@ -59,19 +59,19 @@ $padding-popover: 0.5rem;
     }
 
     [data-popper-placement^='top'] > .af-popover__arrow {
-      bottom: $arrow-offset;
+      bottom: -4px;
     }
 
     [data-popper-placement^='bottom'] > .af-popover__arrow {
-      top: $arrow-offset;
+      top: -4px;
     }
 
     [data-popper-placement^='right'] > .af-popover__arrow {
-      left: $arrow-offset;
+      left: -12px;
     }
 
     [data-popper-placement^='left'] > .af-popover__arrow {
-      right: $arrow-offset;
+      right: 4px;
     }
   }
 

--- a/packages/popover/src/popover.scss
+++ b/packages/popover/src/popover.scss
@@ -1,17 +1,19 @@
 @import '@axa-fr/react-toolkit-core/src/common/scss/core.scss';
 
-$size-arrow: 16px;
+$arrow-size: 16px;
 $arrow-offset: -4px;
 $padding-popover: 0.5rem;
 
 .af-popover {
   &__wrapper {
+    display: inline-block;
     background: inherit;
     border: 0;
     padding: 0;
   }
 
   &__container {
+    cursor: initial;
     display: inline-block;
 
     &-pop {
@@ -43,35 +45,35 @@ $padding-popover: 0.5rem;
     }
 
     .af-popover__arrow {
-      width: $size-arrow;
-      height: $size-arrow;
+      width: $arrow-size;
+      height: $arrow-size;
       position: absolute;
       z-index: -1;
 
       &::before {
         content: '';
         background: $color-azur;
-        width: $size-arrow;
-        height: $size-arrow;
+        width: $arrow-size;
+        height: $arrow-size;
         transform: rotate(45deg);
         position: absolute;
       }
     }
 
     [data-popper-placement^='top'] > .af-popover__arrow {
-      bottom: -4px;
+      bottom: $arrow-offset;
     }
 
     [data-popper-placement^='bottom'] > .af-popover__arrow {
-      top: -4px;
+      top: $arrow-offset;
     }
 
     [data-popper-placement^='right'] > .af-popover__arrow {
-      left: -12px;
+      left: $arrow-offset;
     }
 
     [data-popper-placement^='left'] > .af-popover__arrow {
-      right: 4px;
+      right: $arrow-offset;
     }
   }
 


### PR DESCRIPTION
Change the way we detect that we click outside the popover to dismiss it to remove the `stopPropagation` on body's event `click`.

Note, I also fixed:
- the arrow position
- unused props

Fixes #643