### PR TITLE
fix(table-pager): add flexible width when active page number is large

### DIFF
--- a/packages/table/src/Pager/pager.scss
+++ b/packages/table/src/Pager/pager.scss
@@ -18,7 +18,7 @@
     &--active {
       background: $color-axa;
       color: $white;
-      width: 1.9rem;
+      min-width: 1.9rem;
       height: 1.9rem;
       text-align: center;
 

--- a/storybook/storybook/src/packages/table/src/Pager/Pager.stories.js
+++ b/storybook/storybook/src/packages/table/src/Pager/Pager.stories.js
@@ -19,6 +19,20 @@ const PagerStory = () => (
   />
 );
 
+const ManyPagesStory = () => (
+  <Pager
+    classModifier={text('classModifier', '')}
+    className={text('className', '')}
+    currentPage={number('currentPage', 4225)}
+    mode={select('mode', Modes, Modes.default)}
+    nextLabel={text('nextLabel', 'Next »')}
+    ofLabel={text('ofLabel', 'of')}
+    onChange={action('onChange')}
+    previousLabel={text('previousLabel', '« Previous')}
+    numberPages={number('numberPages', 5000)}
+  />
+);
+
 const LightStory = () => (
   <Pager
     classModifier={text('classModifier', '')}
@@ -42,4 +56,5 @@ stories.addParameters({
 });
 
 stories.add('Default', PagerStory);
+stories.add('ManyPages', ManyPagesStory);
 stories.add('Light', LightStory);


### PR DESCRIPTION
## Related issue

### Reference to the issue

#689 

### Description of the issue

When the table had 4-digit number of pages, the active page was truncated and blue bullet not centered

### Person(s) for reviewing proposed changes

@samuel-gomez @guillaumechervet @youf-olivier @LeGrandKhan
