### PR TITLE
fix(new-ds): fix broken link to template pugs

### DIFF
--- a/storybook/design-system/src/components/form/mixins/mixin-form-field-card.pug
+++ b/storybook/design-system/src/components/form/mixins/mixin-form-field-card.pug
@@ -4,7 +4,7 @@ mixin formFieldCardHeaderCheckbox({ name='', modifier= '', disabled=false, forId
       input.af-form__input-checkbox(name=name type="checkbox" value="on" id=forId disabled= disabled || null checked= checked || null)
       label.af-form__label(for=forId)
         span.af-form__indicator
-          include ../../../pages/style/icons/templates/ok.pug
+          include ../../../pages/guidelines/icones/templates/ok.pug
         span.af-form__description
           p.af-rccard-header__title  Référence
           p.af-rccard-header__subtitle 50 € / mois

--- a/storybook/design-system/src/components/form/mixins/mixin-form-field-checkbox.pug
+++ b/storybook/design-system/src/components/form/mixins/mixin-form-field-checkbox.pug
@@ -3,6 +3,6 @@ mixin formFieldCheckbox({ name='defaultname', modifier= '', label= 'default labe
     input.af-form__input-checkbox(name=name type="checkbox" id=`checkbox${id}` disabled= disabled || null checked= checked || null)
     label.af-form__label(for=`checkbox${id}`)
       span.af-form__indicator
-        include ../../../pages/style/icons/templates/ok.pug
+        include ../../../pages/guidelines/icones/templates/ok.pug
       span.af-form__description
         | #{label}

--- a/storybook/design-system/src/components/form/mixins/mixin-form-field-select.pug
+++ b/storybook/design-system/src/components/form/mixins/mixin-form-field-select.pug
@@ -9,9 +9,9 @@ mixin formFieldSelect({ className= '', hasInfobulle= false, hasClear=false, modi
         option(value="2") Option 2
         option(value="3") Option 3
         option(value="4") Option 4
-      include ../../../pages/style/icons/templates/menu-down.pug
+      include ../../../pages/guidelines/icones/templates/menu-down.pug
       if(hasInfobulle)
         +formHelp()
       if modifier === "valid"
-        include ../../../pages/style/icons/templates/ok.pug
+        include ../../../pages/guidelines/icones/templates/ok.pug
     +formMessage({modifierMessage, textMessage, iconMessage})

--- a/storybook/design-system/src/components/form/mixins/mixin-form-field-text.pug
+++ b/storybook/design-system/src/components/form/mixins/mixin-form-field-text.pug
@@ -6,9 +6,9 @@ mixin formFieldText({ hasInfobulle= false, hasClear=false, modifier= '', textMes
       input.af-form__input-text(class=(hasInfobulle) ? ` af-form__input-text--hasinfobulle` : '' name="inputtextname" type="text" disabled= disabled || null)
       if hasClear
         .af-form__clear(role="button" tabindex="-1")
-          include ../../../pages/style/icons/templates/close.pug
+          include ../../../pages/guidelines/icones/templates/close.pug
       if hasInfobulle
         +formHelp()
       if modifier === "valid"
-        include ../../../pages/style/icons/templates/ok.pug
+        include ../../../pages/guidelines/icones/templates/ok.pug
     +formMessage({modifierMessage, textMessage, iconMessage})

--- a/storybook/design-system/src/components/form/mixins/mixin-form-message.pug
+++ b/storybook/design-system/src/components/form/mixins/mixin-form-message.pug
@@ -4,7 +4,7 @@ mixin formMessage({modifierMessage= '', textMessage='', iconMessage= ''})
       | #{textMessage}
     else
       if iconMessage === "warning-sign"
-        include ../../../pages/style/icons/templates/warning-sign.pug
+        include ../../../pages/guidelines/icones/templates/warning-sign.pug
       else
-        include ../../../pages/style/icons/templates/exclamation-sign.pug
+        include ../../../pages/guidelines/icones/templates/exclamation-sign.pug
       span.af-form__error-text #{textMessage}

--- a/storybook/design-system/src/pages/atoms/badge/templates/infoIcon.pug
+++ b/storybook/design-system/src/pages/atoms/badge/templates/infoIcon.pug
@@ -1,2 +1,2 @@
 span.af-badge.af-badge--error.af-badge--hasIcon
-  include ../../../style/icons/templates/bell.pug
+  include ../../../guidelines/icones/templates/bell.pug

--- a/storybook/design-system/src/pages/atoms/button/templates/button-icon.pug
+++ b/storybook/design-system/src/pages/atoms/button/templates/button-icon.pug
@@ -1,24 +1,24 @@
 button.btn.af-btn.af-btn--hasiconLeft
   span.af-btn__text Button with left icon
-  include ../../../style/icons/templates/arrowthin-left.pug
+  include ../../../guidelines/icones/templates/arrowthin-left.pug
 button.btn.af-btn.af-btn--hasiconLeft.af-btn--disabled
   span.af-btn__text Button disabled with left icon
-  include ../../../style/icons/templates/arrowthin-left.pug
+  include ../../../guidelines/icones/templates/arrowthin-left.pug
 button.btn.af-btn.af-btn--hasiconLeft.af-btn--success
   span.af-btn__text Button success with left icon
-  include ../../../style/icons/templates/arrowthin-left.pug
+  include ../../../guidelines/icones/templates/arrowthin-left.pug
 button.btn.af-btn.af-btn--hasiconLeft.af-btn--danger
   span.af-btn__text Button danger with left icon
-  include ../../../style/icons/templates/arrowthin-left.pug
+  include ../../../guidelines/icones/templates/arrowthin-left.pug
 button.btn.af-btn.af-btn--hasiconRight
   span.af-btn__text Button with right icon
-  include ../../../style/icons/templates/arrowthin-right.pug
+  include ../../../guidelines/icones/templates/arrowthin-right.pug
 button.btn.af-btn.af-btn--hasiconRight.af-btn--disabled
   span.af-btn__text Button disabled with right icon
-  include ../../../style/icons/templates/arrowthin-right.pug
+  include ../../../guidelines/icones/templates/arrowthin-right.pug
 button.btn.af-btn.af-btn--hasiconRight.af-btn--success
   span.af-btn__text Button success with right icon
-  include ../../../style/icons/templates/arrowthin-right.pug
+  include ../../../guidelines/icones/templates/arrowthin-right.pug
 button.btn.af-btn.af-btn--hasiconRight.af-btn--danger
   span.af-btn__text Button danger with right icon
-  include ../../../style/icons/templates/arrowthin-right.pug
+  include ../../../guidelines/icones/templates/arrowthin-right.pug

--- a/storybook/design-system/src/pages/atoms/button/templates/button-reverse.pug
+++ b/storybook/design-system/src/pages/atoms/button/templates/button-reverse.pug
@@ -2,13 +2,13 @@ button.btn.af-btn.af-btn--reverse(tabindex="-1") Button AF reverse
 button.btn.af-btn.af-btn--reverse.af-btn--disabled(tabindex="-1") Button AF disabled reverse
 button.btn.af-btn.af-btn--reverse.af-btn--hasiconLeft(tabindex="-1")
   span.af-btn__text Button with left icon
-  include ../../../style/icons/templates/arrowthin-left.pug
+  include ../../../guidelines/icones/templates/arrowthin-left.pug
 button.btn.af-btn.af-btn--reverse.af-btn--hasiconRight(tabindex="-1")
   span.af-btn__text Button with right icon
-  include ../../../style/icons/templates/arrowthin-right.pug
+  include ../../../guidelines/icones/templates/arrowthin-right.pug
 button.btn.af-btn.af-btn--reverse.af-btn--hasiconLeft(tabindex="-1")
   span.af-btn__text Button with left icon
-  include ../../../style/icons/templates/globe.pug
+  include ../../../guidelines/icones/templates/globe.pug
 button.btn.af-btn.af-btn--reverse.af-btn--disabled.af-btn--hasiconRight(tabindex="-1")
   span.af-btn__text Button disabled with right icon
-  include ../../../style/icons/templates/arrowthin-right.pug
+  include ../../../guidelines/icones/templates/arrowthin-right.pug

--- a/storybook/design-system/src/pages/atoms/button/templates/circle.pug
+++ b/storybook/design-system/src/pages/atoms/button/templates/circle.pug
@@ -4,31 +4,31 @@ each mod in modifier
   .tk-block-demo
     div.fordemo
       a(class=`af-btn--${mod}` href="#" role="button" )
-        include ../../../style/icons/templates/pushpin.pug
+        include ../../../guidelines/icones/templates/pushpin.pug
     div.fordemo
       a(class=`af-btn--${mod}` href="#" role="button" )
-        include ../../../style/icons/templates/print.pug
+        include ../../../guidelines/icones/templates/print.pug
     div.fordemo
       a(class=`af-btn--${mod}` href="#" role="button" )
-        include ../../../style/icons/templates/arrow-xs-down.pug
+        include ../../../guidelines/icones/templates/arrow-xs-down.pug
     div.fordemo
       a(class=`af-btn--${mod}` href="#" role="button" )
-        include ../../../style/icons/templates/heart.pug
+        include ../../../guidelines/icones/templates/heart.pug
     div.fordemo
       a(class=`af-btn--${mod}` href="#" role="button" )
-        include ../../../style/icons/templates/eye-open.pug
+        include ../../../guidelines/icones/templates/eye-open.pug
     div.fordemo
       a(class=`af-btn--${mod}` href="#" role="button" )
-        include ../../../style/icons/templates/menu-hamburger.pug
+        include ../../../guidelines/icones/templates/menu-hamburger.pug
     div.fordemo
       a(class=`af-btn--${mod}` href="#" role="button" )
-        include ../../../style/icons/templates/remove.pug
+        include ../../../guidelines/icones/templates/remove.pug
     div.fordemo
       a(class=`af-btn--${mod}` href="#" role="button" )
-        include ../../../style/icons/templates/filter.pug
+        include ../../../guidelines/icones/templates/filter.pug
     div.fordemo
       a(class=`af-btn--${mod}` href="#" role="button" )
-        include ../../../style/icons/templates/floppy-disk.pug
+        include ../../../guidelines/icones/templates/floppy-disk.pug
     div.fordemo
       a(class=`af-btn--${mod}` href="#" role="button" )
-        include ../../../style/icons/templates/open.pug
+        include ../../../guidelines/icones/templates/open.pug

--- a/storybook/design-system/src/pages/atoms/button/templates/ghost.pug
+++ b/storybook/design-system/src/pages/atoms/button/templates/ghost.pug
@@ -2,29 +2,29 @@
   a.af-link(href="#") Simple link
 .tk-block-demo
   a.af-link.af-link--hasIconLeft(href="#")
-    include ../../../style/icons/templates/plus.pug
+    include ../../../guidelines/icones/templates/plus.pug
     span.af-link__text Link with icon
 .tk-block-demo
   a.af-link.af-link--hasIconLeft(href="#")
-    include ../../../style/icons/templates/arrowthin-left.pug
+    include ../../../guidelines/icones/templates/arrowthin-left.pug
     span.af-link__text Back Link
 .tk-block-demo
   a.af-link.af-link--hasIconLeft(href="#")
-    include ../../../style/icons/templates/plus-sign.pug
+    include ../../../guidelines/icones/templates/plus-sign.pug
     span.af-link__text Link plus
 .tk-block-demo
   a.af-link.af-link--hasIconLeft(href="#")
-    include ../../../style/icons/templates/pencil.pug
+    include ../../../guidelines/icones/templates/pencil.pug
     span.af-link__text Link edition
 .tk-block-demo
   a.af-link.af-link--hasIconLeft(href="#")
-    include ../../../style/icons/templates/print.pug
+    include ../../../guidelines/icones/templates/print.pug
     span.af-link__text Link print
 .tk-block-demo
   a.af-link.af-link--hasIconLeft(href="#")
-    include ../../../style/icons/templates/question-sign.pug
+    include ../../../guidelines/icones/templates/question-sign.pug
     span.af-link__text Link question
 .tk-block-demo
   a.af-link.af-link--hasIconRight(href="#")
     span.af-link__text Link new window
-    include ../../../style/icons/templates/new-window.pug
+    include ../../../guidelines/icones/templates/new-window.pug

--- a/storybook/design-system/src/pages/atoms/list/templates/withIcon.pug
+++ b/storybook/design-system/src/pages/atoms/list/templates/withIcon.pug
@@ -1,23 +1,23 @@
 .tk-block-demo
   ul.af-list.af-list--check
     li.af-list__item
-      include ../../../style/icons/templates/ok.pug
+      include ../../../guidelines/icones/templates/ok.pug
       |  CSS et SASS
     li.af-list__item
-      include ../../../style/icons/templates/ok.pug
+      include ../../../guidelines/icones/templates/ok.pug
       |  ReactJS
     li.af-list__item
-      include ../../../style/icons/templates/ok.pug
+      include ../../../guidelines/icones/templates/ok.pug
       |  ES6
     li.af-list__item
-      include ../../../style/icons/templates/ok.pug
+      include ../../../guidelines/icones/templates/ok.pug
       |  GIT
     li.af-list__item
-      include ../../../style/icons/templates/ok.pug
+      include ../../../guidelines/icones/templates/ok.pug
       |  Webpack
     li.af-list__item
-      include ../../../style/icons/templates/ok.pug
+      include ../../../guidelines/icones/templates/ok.pug
       |  Typescript
     li.af-list__item
-      include ../../../style/icons/templates/ok.pug
+      include ../../../guidelines/icones/templates/ok.pug
       |  ReasonML

--- a/storybook/design-system/src/pages/atoms/popover/templates/classic.pug
+++ b/storybook/design-system/src/pages/atoms/popover/templates/classic.pug
@@ -2,28 +2,28 @@
   .af-popover__container
     .af-popover__container-over
       a.btn.af-btn--circle(href="#" role="button" )
-        include ../../../style/icons/templates/pushpin.pug
+        include ../../../guidelines/icones/templates/pushpin.pug
     .af-popover__container-pop(data-placement="top" style=`text-align: center;position: absolute; transform: translate3d(32px, -7px, 0px); top: 0px; left: 0px; will-change: transform;` )
       | pushpin
       span.af-popover__arrow
   .af-popover__container
     .af-popover__container-over
       a.btn.af-btn--circle(href="#" role="button" )
-        include ../../../style/icons/templates/print.pug
+        include ../../../guidelines/icones/templates/print.pug
     .af-popover__container-pop(data-placement="top" style=`text-align: center;position: absolute; transform: translate3d(44px, -7px, 0px); top: 0px; left: 0px; will-change: transform;` )
       | print
       span.af-popover__arrow
   .af-popover__container
     .af-popover__container-over
       a.btn.af-btn--circle(href="#" role="button" )
-        include ../../../style/icons/templates/arrow-xs-down.pug
+        include ../../../guidelines/icones/templates/arrow-xs-down.pug
     .af-popover__container-pop(data-placement="top" style=`text-align: center;position: absolute; transform: translate3d(9px, -7px, 0px); top: 0px; left: 0px; will-change: transform;` )
       | arrow-xs-down
       span.af-popover__arrow
   .af-popover__container
     .af-popover__container-over
       a.btn.af-btn--circle(href="#" role="button" )
-        include ../../../style/icons/templates/heart.pug
+        include ../../../guidelines/icones/templates/heart.pug
     .af-popover__container-pop(data-placement="top" style=`text-align: center;position: absolute; transform: translate3d(42px, -7px, 0px); top: 0px; left: 0px; will-change: transform;` )
       | heart
       span.af-popover__arrow

--- a/storybook/design-system/src/pages/get-started/how-to-contribute/markdown/content.md
+++ b/storybook/design-system/src/pages/get-started/how-to-contribute/markdown/content.md
@@ -1,3 +1,5 @@
+# Contributing to @axa-fr/react-toolkit
+
 ## Installation
 
 To get started with the repository:
@@ -26,12 +28,12 @@ If you want to use these projects, you must:
 
 ```sh
 cd storybook/design-system
-npm i
+npm ci
 ```
 
 ```sh
 cd storybook/storybook
-npm i
+npm ci
 ```
 
 ## How to work on a component
@@ -60,7 +62,7 @@ And then if you want to work on it, in isolation mode, you can run storybook
 npm run storybook
 ```
 
-After all this, if your development affect css, you can run `npx gulp all` to regenerate css
+After all this, if your development affect css, you can run `npm run style` to regenerate css
 
 ## Other usefull commands
 
@@ -74,9 +76,9 @@ By default, `npm test` also runs the linter.
 You can skip this by calling `jest` directly:
 
 ```sh
-$ npx jest
-$ npx jest --watch
-$ npx jest --config jest.config.json
+$ npm jest
+$ npm jest --watch
+$ npm jest --config jest.config.json
 # etc
 ```
 

--- a/storybook/design-system/src/pages/molecules/alert/templates/alertComplex.pug
+++ b/storybook/design-system/src/pages/molecules/alert/templates/alertComplex.pug
@@ -1,9 +1,9 @@
 .af-alert.af-alert--success
   button.af-alert__icon-close
-    include ../../../style/icons/templates/close.pug
+    include ../../../guidelines/icones/templates/close.pug
   h3.af-alert__title
     .af-alert__title-icon
-      include ../../../style/icons/templates/ok.pug
+      include ../../../guidelines/icones/templates/ok.pug
     .af-alert__title-text
       | Les caves et les garages situés dans le même corps de bâtiment que le logement assuré sont garantis d'office
   .af-alert__content

--- a/storybook/design-system/src/pages/molecules/alert/templates/alertComplexDanger.pug
+++ b/storybook/design-system/src/pages/molecules/alert/templates/alertComplexDanger.pug
@@ -1,9 +1,9 @@
 .af-alert.af-alert--error
   button.af-alert__icon-close
-    include ../../../style/icons/templates/close.pug
+    include ../../../guidelines/icones/templates/close.pug
   h3.af-alert__title
     .af-alert__title-icon
-      include ../../../style/icons/templates/exclamation-sign.pug
+      include ../../../guidelines/icones/templates/exclamation-sign.pug
     .af-alert__title-text
       | Les caves et les garages situés dans le même corps de bâtiment que le logement assuré sont garantis d'office
   .af-alert__content

--- a/storybook/design-system/src/pages/molecules/alert/templates/alertSimpleDanger.pug
+++ b/storybook/design-system/src/pages/molecules/alert/templates/alertSimpleDanger.pug
@@ -1,8 +1,8 @@
 .af-alert.af-alert--danger
   button.af-alert__icon-close
-    include ../../../style/icons/templates/close.pug
+    include ../../../guidelines/icones/templates/close.pug
   h3.af-alert__title
     .af-alert__title-icon
-      include ../../../style/icons/templates/alert.pug
+      include ../../../guidelines/icones/templates/alert.pug
     .af-alert__title-text
       | Les caves et les garages situés dans le même corps de bâtiment que le logement assuré sont garantis d'office

--- a/storybook/design-system/src/pages/molecules/alert/templates/alertSimpleInfo.pug
+++ b/storybook/design-system/src/pages/molecules/alert/templates/alertSimpleInfo.pug
@@ -1,8 +1,8 @@
 .af-alert.af-alert--info
   button.af-alert__icon-close
-    include ../../../style/icons/templates/close.pug
+    include ../../../guidelines/icones/templates/close.pug
   h3.af-alert__title
     .af-alert__title-icon
-      include ../../../style/icons/templates/info-sign.pug
+      include ../../../guidelines/icones/templates/info-sign.pug
     .af-alert__title-text
       | Les caves et les garages situés dans le même corps de bâtiment que le logement assuré sont garantis d'office

--- a/storybook/design-system/src/pages/molecules/alert/templates/alertSimpleSuccess.pug
+++ b/storybook/design-system/src/pages/molecules/alert/templates/alertSimpleSuccess.pug
@@ -1,8 +1,8 @@
 .af-alert.af-alert--success
   button.af-alert__icon-close
-    include ../../../style/icons/templates/close.pug
+    include ../../../guidelines/icones/templates/close.pug
   h3.af-alert__title
     .af-alert__title-icon
-      include ../../../style/icons/templates/ok.pug
+      include ../../../guidelines/icones/templates/ok.pug
     .af-alert__title-text
       | Les caves et les garages situés dans le même corps de bâtiment que le logement assuré sont garantis d'office

--- a/storybook/design-system/src/pages/molecules/form-datepicker/templates/form-datepicker.pug
+++ b/storybook/design-system/src/pages/molecules/form-datepicker/templates/form-datepicker.pug
@@ -10,4 +10,4 @@ block input
       .react-datepicker__input-container
         input#uniqueid.af-datepicker.react-datepicker-ignore-onclickoutside(type='text', name='placeName', value='11/26/2017')
     include ./popper
-    include ../../../style/icons/templates/calendar.pug
+    include ../../../guidelines/icones/templates/calendar.pug

--- a/storybook/design-system/src/pages/molecules/form-file/templates/form-file-list-error.pug
+++ b/storybook/design-system/src/pages/molecules/form-file/templates/form-file-list-error.pug
@@ -10,7 +10,7 @@ block input
       div Glissez/d&eacute;posez vos fichiers
       input(accept='image/jpeg, image/png, application/*' type='file' style='position: absolute; inset: 0px; opacity: 0.00001; pointer-events: none;' autocomplete='off' name='placeImage')
     button.af-btn.af-btn--file.af-btn--hasiconLeft(type='button')
-      include ../../../style/icons/templates/open.pug
+      include ../../../guidelines/icones/templates/open.pug
       |  Parcourir
   small.af-form__help Enter the place name, ex : Webcenter
   .custom-table-file.af-file-table
@@ -25,7 +25,7 @@ block input
         span
           .af-popover__container
             .af-popover__container-over(role='presentation')
-              include ../../../style/icons/templates/picture.pug
+              include ../../../guidelines/icones/templates/picture.pug
         span error-file.jpg
         span 100Mo
         button.af-link.af-link--delete-file(type='button')
@@ -34,13 +34,13 @@ block input
         span
           .af-popover__container
             .af-popover__container-over(role='presentation')
-              include ../../../style/icons/templates/picture.pug
+              include ../../../guidelines/icones/templates/picture.pug
         span fichier.png
         span 100Mo
         button.af-link.af-link--delete-file(type='button')
           span.af-link__text Supprimer
       li.af-form__file-line
-        include ../../../style/icons/templates/file.pug
+        include ../../../guidelines/icones/templates/file.pug
         span fichier.csv
         span 100ko
         button.af-link.af-link--delete-file(type='button')

--- a/storybook/design-system/src/pages/molecules/form-file/templates/form-file-list.pug
+++ b/storybook/design-system/src/pages/molecules/form-file/templates/form-file-list.pug
@@ -10,7 +10,7 @@ block input
       div Glissez/d&eacute;posez vos fichiers
       input(accept='image/jpeg, image/png, application/*' type='file' style='position: absolute; inset: 0px; opacity: 0.00001; pointer-events: none;' autocomplete='off' name='placeImage')
     button.af-btn.af-btn--file.af-btn--hasiconLeft(type='button')
-      include ../../../style/icons/templates/open.pug
+      include ../../../guidelines/icones/templates/open.pug
       |  Parcourir
   small.af-form__help Enter the place name, ex : Webcenter
   .custom-table-file.af-file-table
@@ -19,7 +19,7 @@ block input
         span
           .af-popover__container
             .af-popover__container-over(role='presentation')
-              include ../../../style/icons/templates/picture.pug
+              include ../../../guidelines/icones/templates/picture.pug
         span error-file.jpg
         span 100Mo
         button.af-link.af-link--delete-file(type='button')
@@ -28,13 +28,13 @@ block input
         span
           .af-popover__container
             .af-popover__container-over(role='presentation')
-              include ../../../style/icons/templates/picture.pug
+              include ../../../guidelines/icones/templates/picture.pug
         span fichier.png
         span 100Mo
         button.af-link.af-link--delete-file(type='button')
           span.af-link__text Supprimer
       li.af-form__file-line
-        include ../../../style/icons/templates/file.pug
+        include ../../../guidelines/icones/templates/file.pug
         span fichier.csv
         span 100ko
         button.af-link.af-link--delete-file(type='button')

--- a/storybook/design-system/src/pages/molecules/form-file/templates/form-file.pug
+++ b/storybook/design-system/src/pages/molecules/form-file/templates/form-file.pug
@@ -11,5 +11,5 @@ block input
         div Glissez/d&eacute;posez vos fichiers
         input(accept='image/jpeg, image/png, application/*' type='file' style='position: absolute; inset: 0px; opacity: 0.00001; pointer-events: none;' multiple='' autocomplete='off' name='placeImage')
       button.af-btn.af-btn--file.af-btn--hasiconLeft(type='button')
-        include ../../../style/icons/templates/open.pug
+        include ../../../guidelines/icones/templates/open.pug
         |  Parcourir

--- a/storybook/design-system/src/pages/molecules/form-pass/templates/form-pass.pug
+++ b/storybook/design-system/src/pages/molecules/form-pass/templates/form-pass.pug
@@ -9,7 +9,7 @@ each level in levels
           .af-form__pass-strength
           input#uniqueid.af-form__input-text(name="inputpassword" value="" tabindex="" type="password")
           button.af-form__pass-btn(type="button")
-            include ../../../style/icons/templates/eye-open.pug
+            include ../../../guidelines/icones/templates/eye-open.pug
         .af-popover__container
           .af-popover__container-over
             button.af-btn--circle-small

--- a/storybook/design-system/src/pages/molecules/navigation/templates/classic.pug
+++ b/storybook/design-system/src/pages/molecules/navigation/templates/classic.pug
@@ -11,7 +11,7 @@
           li.af-nav__item(role="none" class=(item.active) ? "af-nav__item--active" : "" class=(item.children) ? "af-nav__item--haschild" : "")
             a.af-nav__link(role="menuitem" href=item.href tabindex=(index === 0) ? "0" : "-1" aria-haspopup=(item.children) ? true : false aria-expanded=(item.children) ? true : false) #{item.label}
             if item.children
-              include ../../../style/icons/templates/arrow-xs-down.pug
+              include ../../../guidelines/icones/templates/arrow-xs-down.pug
               ul.af-nav__list.af-nav__list--children(role="menu" aria-label=item.label)
                 each child in item.children
                   li.af-nav__item(role="none" class=(child.active) ? "af-nav__item--active" : "")

--- a/storybook/design-system/src/pages/molecules/steps-new/templates/steps-new-sample2.pug
+++ b/storybook/design-system/src/pages/molecules/steps-new/templates/steps-new-sample2.pug
@@ -4,24 +4,24 @@
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber 1
         .af-steps-list-stepTitle Previous step
-        include ../../../style/icons/templates/arrow-rounded-right.pug
+        include ../../../guidelines/icones/templates/arrow-rounded-right.pug
     li.af-steps-list-step.past(title="Etape 2")
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber 2
         .af-steps-list-stepTitle Previous step
-        include ../../../style/icons/templates/arrow-rounded-right.pug
+        include ../../../guidelines/icones/templates/arrow-rounded-right.pug
     li.af-steps-list-step.on(title="Etape 3")
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber 3
         .af-steps-list-stepTitle Current step
-        include ../../../style/icons/templates/arrow-rounded-right.pug
+        include ../../../guidelines/icones/templates/arrow-rounded-right.pug
     li.af-steps-list-step.disabled(title="Etape 3")
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber 4
         .af-steps-list-stepTitle Next step
-        include ../../../style/icons/templates/arrow-rounded-right.pug
+        include ../../../guidelines/icones/templates/arrow-rounded-right.pug
     li.af-steps-list-step.disabled(title="Etape finale")
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber &nbsp;
-          include ../../../style/icons/templates/ok.pug
+          include ../../../guidelines/icones/templates/ok.pug
         .af-steps-list-stepTitle Confirmation

--- a/storybook/design-system/src/pages/molecules/steps-new/templates/steps-new-sample3.pug
+++ b/storybook/design-system/src/pages/molecules/steps-new/templates/steps-new-sample3.pug
@@ -4,24 +4,24 @@
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber 1
         .af-steps-list-stepTitle Previous step
-        include ../../../style/icons/templates/arrow-rounded-right.pug
+        include ../../../guidelines/icones/templates/arrow-rounded-right.pug
     li.af-steps-list-step.past(title="Etape 2")
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber 2
         .af-steps-list-stepTitle Previous step
-        include ../../../style/icons/templates/arrow-rounded-right.pug
+        include ../../../guidelines/icones/templates/arrow-rounded-right.pug
     li.af-steps-list-step.past(title="Etape 3")
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber 3
         .af-steps-list-stepTitle Previous step
-        include ../../../style/icons/templates/arrow-rounded-right.pug
+        include ../../../guidelines/icones/templates/arrow-rounded-right.pug
     li.af-steps-list-step.past(title="Etape 3")
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber 4
         .af-steps-list-stepTitle Previous step
-        include ../../../style/icons/templates/arrow-rounded-right.pug
+        include ../../../guidelines/icones/templates/arrow-rounded-right.pug
     li.af-steps-list-step.on(title="Etape finale")
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber &nbsp;
-          include ../../../style/icons/templates/ok.pug
+          include ../../../guidelines/icones/templates/ok.pug
         .af-steps-list-stepTitle Confirmation

--- a/storybook/design-system/src/pages/molecules/steps-new/templates/steps-new.pug
+++ b/storybook/design-system/src/pages/molecules/steps-new/templates/steps-new.pug
@@ -4,14 +4,14 @@
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber 1
         .af-steps-list-stepTitle Current step
-        include ../../../style/icons/templates/arrow-rounded-right.pug
+        include ../../../guidelines/icones/templates/arrow-rounded-right.pug
     li.af-steps-list-step.disabled(title="Etape 2")
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber 2
         .af-steps-list-stepTitle Next step
-        include ../../../style/icons/templates/arrow-rounded-right.pug
+        include ../../../guidelines/icones/templates/arrow-rounded-right.pug
     li.af-steps-list-step.disabled(title="Etape finale")
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber &nbsp;
-          include ../../../style/icons/templates/ok.pug
+          include ../../../guidelines/icones/templates/ok.pug
         .af-steps-list-stepTitle Confirmation

--- a/storybook/design-system/src/pages/molecules/steps/templates/classic.pug
+++ b/storybook/design-system/src/pages/molecules/steps/templates/classic.pug
@@ -19,5 +19,5 @@
     li.af-steps-list-step(title="Etape finale")
       .af-steps-list-stepLabel
         .af-steps-list-stepNumber
-          include ../../../style/icons/templates/ok.pug
+          include ../../../guidelines/icones/templates/ok.pug
         .af-steps-list-stepTitle Confirmation

--- a/storybook/design-system/src/pages/molecules/table/templates/headerCell.pug
+++ b/storybook/design-system/src/pages/molecules/table/templates/headerCell.pug
@@ -5,8 +5,8 @@ mixin headerCell(item)
         button.af-btn.af-btn--table-sorting(class=item.isActive ? "af-btn--table-sorting--active" : "" role="button")
           | #{item.label}
           if item.isActive
-            include ../../../style/icons/templates/arrow-xs-down.pug
+            include ../../../guidelines/icones/templates/arrow-xs-down.pug
           else
-            include ../../../style/icons/templates/sorting.pug
+            include ../../../guidelines/icones/templates/sorting.pug
       else
         | #{item.label}

--- a/storybook/design-system/src/pages/molecules/table/templates/line.pug
+++ b/storybook/design-system/src/pages/molecules/table/templates/line.pug
@@ -19,6 +19,6 @@ mixin line(item)
       +status(item.status)
     td.af-table__cell
       a.af-link.af-link--hasIconLeft(href="#")
-        include ../../../style/icons/templates/pencil.pug
+        include ../../../guidelines/icones/templates/pencil.pug
         span.af-link__text
           | Consulter

--- a/storybook/design-system/src/pages/molecules/table/templates/status.pug
+++ b/storybook/design-system/src/pages/molecules/table/templates/status.pug
@@ -3,13 +3,13 @@ mixin status(code)
     case code
       when 1
         span.glyphicon-ring.glyphicon-ring--banque
-          include ../../../style/icons/templates/option-horizontal.pug
+          include ../../../guidelines/icones/templates/option-horizontal.pug
         | En cours
       when 2
         span.glyphicon-ring.glyphicon-ring--warning
-          include ../../../style/icons/templates/arrowthin-right.pug
+          include ../../../guidelines/icones/templates/arrowthin-right.pug
         | Transmis
       default
         span.glyphicon-ring.glyphicon-ring--success
-          include ../../../style/icons/templates/ok.pug
+          include ../../../guidelines/icones/templates/ok.pug
         | Clos

--- a/storybook/design-system/src/pages/molecules/tabs/templates/tabs-complex.pug
+++ b/storybook/design-system/src/pages/molecules/tabs/templates/tabs-complex.pug
@@ -3,13 +3,13 @@
     li.af-tabs__item.af-tabs__item--has-icon-left.af-tabs__item--active
       button.af-tabs__link
         span
-          include ../../../style/icons/templates/ok.pug
+          include ../../../guidelines/icones/templates/ok.pug
           |  Title with left icon
     li.af-tabs__item.af-tabs__item--has-icon-right
       button.af-tabs__link
         span
           | Title with right icon
-          include ../../../style/icons/templates/facetime-video.pug
+          include ../../../guidelines/icones/templates/facetime-video.pug
     li.af-tabs__item
       button.af-tabs__link
         span
@@ -20,6 +20,6 @@
         span
           | Title with badge and left icon
           span.af-badge.af-badge--error  Lorem ipsum
-          include ../../../style/icons/templates/facetime-video.pug
+          include ../../../guidelines/icones/templates/facetime-video.pug
   .af-tabs__content
     .af-tabs__pane Content of my first tab

--- a/storybook/design-system/src/pages/molecules/tabs/templates/tabs-long-text.pug
+++ b/storybook/design-system/src/pages/molecules/tabs/templates/tabs-long-text.pug
@@ -3,13 +3,13 @@
     li.af-tabs__item.af-tabs__item--active.af-tabs__item--has-icon-left
       button.af-tabs__link
         span
-          include ../../../style/icons/templates/ok.pug
+          include ../../../guidelines/icones/templates/ok.pug
           |  Title with left icon
     li.af-tabs__item.af-tabs__item--has-icon-right
       button.af-tabs__link
         span
           | Title with right icon
-          include ../../../style/icons/templates/facetime-video.pug
+          include ../../../guidelines/icones/templates/facetime-video.pug
     li.af-tabs__item
       button.af-tabs__link
         span

--- a/storybook/design-system/src/pages/molecules/title-bar/templates/title-bar-complex.pug
+++ b/storybook/design-system/src/pages/molecules/title-bar/templates/title-bar-complex.pug
@@ -2,13 +2,13 @@
   .af-title-bar__wrapper.af-container
     button.af-btn-circle.af-title-bar__mobile-menu
       .af-btn__wrapper
-        include ../../../style/icons/templates/menu-hamburger.pug
+        include ../../../guidelines/icones/templates/menu-hamburger.pug
     h1.af-title-bar__title
       | Slash Design System
       small.af-title-bar__subtitle Sous titre
     .af-title-bar__actions
       a.af-title-bar__link(href="#lien" title="lien titlebar") lien titlebar
       a.af-btn--circle(href="#enregistrer" title="Enregistrer" role="button" tabindex="0")
-        include ../../../style/icons/templates/floppy-disk.pug
+        include ../../../guidelines/icones/templates/floppy-disk.pug
       a.af-btn--circle(href="#imprimer" title="Imprimer" role="button" tabindex="0")
-        include ../../../style/icons/templates/print.pug
+        include ../../../guidelines/icones/templates/print.pug

--- a/storybook/design-system/src/pages/organisms/accordion/templates/accordion-light.pug
+++ b/storybook/design-system/src/pages/organisms/accordion/templates/accordion-light.pug
@@ -5,9 +5,9 @@ include ./data-sample.pug
         .af-accordion__item-header(role="tab" id=`heading${item.id}`)
           h3.af-title.af-accordion__item-title(role="intera")
             if item.active
-              include ../../../style/icons/templates/menu-up.pug
+              include ../../../guidelines/icones/templates/menu-up.pug
             else
-              include ../../../style/icons/templates/menu-down.pug
+              include ../../../guidelines/icones/templates/menu-down.pug
             a.af-accordion__item-toggle(data-toggle="collapse" href=`#collapse${item.id}` aria-expanded="true" aria-controls=`collapse${item.id}`) #{item.title}
         .af-accordion__collapse(role="tabpanel" aria-labelledby=`heading${item.id}` id=`collapse${item.id}` class=(item.active) ? "af-accordion__collapse--open" : "")
           .af-accordion__block

--- a/storybook/design-system/src/pages/organisms/accordion/templates/accordion-right-arrow.pug
+++ b/storybook/design-system/src/pages/organisms/accordion/templates/accordion-right-arrow.pug
@@ -6,9 +6,9 @@ include ./data-sample.pug
         .af-accordion__item-header(role="tab" id=`heading${item.id}`)
           h3.af-accordion__item-title(role="intera")
             if item.active
-              include ../../../style/icons/templates/menu-up.pug
+              include ../../../guidelines/icones/templates/menu-up.pug
             else
-              include ../../../style/icons/templates/menu-down.pug
+              include ../../../guidelines/icones/templates/menu-down.pug
             a.af-accordion__item-toggle(data-toggle="collapse" href=`#collapse${item.id}` aria-expanded="true" aria-controls=`collapse${item.id}`) #{item.title}
         .af-accordion__collapse(role="tabpanel" aria-labelledby=`heading${item.id}` id=`collapse${item.id}` class=(item.active) ? "af-accordion__collapse--open" : "")
           .af-accordion__block

--- a/storybook/design-system/src/pages/organisms/accordion/templates/accordion.pug
+++ b/storybook/design-system/src/pages/organisms/accordion/templates/accordion.pug
@@ -5,9 +5,9 @@ include ./data-sample.pug
         .af-accordion__item-header(role="tab" id=`heading${item.id}`)
           h3.af-accordion__item-title(role="intera")
             if item.active
-              include ../../../style/icons/templates/menu-up.pug
+              include ../../../guidelines/icones/templates/menu-up.pug
             else
-              include ../../../style/icons/templates/menu-down.pug
+              include ../../../guidelines/icones/templates/menu-down.pug
             a.af-accordion__item-toggle(data-toggle="collapse" href=`#collapse${item.id}` aria-expanded="true" aria-controls=`collapse${item.id}`) #{item.title}
         .af-accordion__collapse(role="tabpanel" aria-labelledby=`heading${item.id}` id=`collapse${item.id}` class=(item.active) ? "af-accordion__collapse--open" : "")
           .af-accordion__block

--- a/storybook/design-system/src/pages/organisms/form-filter-inline/templates/form-filter-inline.pug
+++ b/storybook/design-system/src/pages/organisms/form-filter-inline/templates/form-filter-inline.pug
@@ -9,7 +9,7 @@ block children
 
   .af-filter-inline
     span.af-filter-inline__title
-      include ../../../style/icons/templates/filter.pug
+      include ../../../guidelines/icones/templates/filter.pug
       span.af-filter-inline__title-text Filtrer par
     .af-filter-inline__field
       label.af-form__group-label(for="inputtext1") Numéro de contrat
@@ -25,7 +25,7 @@ block children
             option(value="2") Option 2
             option(value="3") Option 3
             option(value="4") Option 4
-          include ../../../style/icons/templates/menu-down.pug
+          include ../../../guidelines/icones/templates/menu-down.pug
     .af-filter-inline__field
       label.af-form__group-label(for="select2") Décision
       .af-form__select
@@ -36,7 +36,7 @@ block children
             option(value="2") Option 2
             option(value="3") Option 3
             option(value="4") Option 4
-          include ../../../style/icons/templates/menu-down.pug
+          include ../../../guidelines/icones/templates/menu-down.pug
     .af-filter-inline__field
       label.af-form__group-label(for="inputtext2") Autre champ
       .af-form__text
@@ -47,5 +47,5 @@ block children
         input.af-form__input-checkbox#checkbox1(name="checkboxname" type="checkbox")
         label.af-form__label(for="checkbox1")
           span.af-form__indicator
-            include ../../../style/icons/templates/ok.pug
+            include ../../../guidelines/icones/templates/ok.pug
           span.af-form__description Transmis

--- a/storybook/design-system/src/pages/organisms/form-filter/templates/form-filter.pug
+++ b/storybook/design-system/src/pages/organisms/form-filter/templates/form-filter.pug
@@ -10,25 +10,25 @@ block children
       header.af-panel__header
         h3.af-panel__title Filtrer
         a.af-panel__reset(href="#reset" title="Ré-initialiser les filtres de recherche")
-          include ../../../style/icons/templates/reset.pug
+          include ../../../guidelines/icones/templates/reset.pug
           span.af-panel__reset-text Reset
       section.af-panel__content
         ul.af-filter-selected
           li.af-filter-selected__item
             span.af-filter-selected__item-text Nom du client
-            include ../../../style/icons/templates/close.pug
+            include ../../../guidelines/icones/templates/close.pug
           li.af-filter-selected__item
             span.af-filter-selected__item-text N° Client
-            include ../../../style/icons/templates/close.pug
+            include ../../../guidelines/icones/templates/close.pug
         .af-accordion.af-accordion--arrow-right(role="tablist" aria-multiselectable="true")
           each item, index in listAccordion
             .af-accordion__item
               .af-accordion__item-header(role="tab" id=`heading${item.id}`)
                 h3.af-accordion__item-title(role="intera")
                   if item.active
-                    include ../../../style/icons/templates/menu-up.pug
+                    include ../../../guidelines/icones/templates/menu-up.pug
                   else
-                    include ../../../style/icons/templates/menu-down.pug
+                    include ../../../guidelines/icones/templates/menu-down.pug
                   a.af-accordion__item-toggle(data-toggle="collapse" href=`#collapse${item.id}` aria-expanded="true" aria-controls=`collapse${item.id}`) #{item.title}
               .af-accordion__collapse(role="tabpanel" aria-labelledby=`heading${item.id}` id=`collapse${item.id}` class=(item.active) ? "af-accordion__collapse--open" : "")
                 .af-accordion__block !{item.content}

--- a/storybook/design-system/src/pages/organisms/header/templates/classic.pug
+++ b/storybook/design-system/src/pages/organisms/header/templates/classic.pug
@@ -8,7 +8,7 @@
           | Nom de l&apos;application
           small.af-header__subtitle Baseline
       .af-contrat
-        include ../../../style/icons/templates/info-sign.pug
+        include ../../../guidelines/icones/templates/info-sign.pug
         dl.af-contrat__list
           dt.af-contrat__word Client :
           dd.af-contrat__def 0123456789 - NOM

--- a/storybook/design-system/src/pages/organisms/modal/templates/modal-large.pug
+++ b/storybook/design-system/src/pages/organisms/modal/templates/modal-large.pug
@@ -5,7 +5,7 @@
       .af-modal__header
         h4.af-modal__header-title Modal Title
         button.af-modal__header-close-btn(type="button" aria-label="Close")
-          include ../../../style/icons/templates/close.pug
+          include ../../../guidelines/icones/templates/close.pug
       .af-modal__body
         p Reprehenderit sit quis aute nisi consequat consequat mollit. Commodo in aliquip consectetur nulla sit anim. Pariatur minim commodo enim ea eu laborum culpa laboris. Labore labore irure ipsum consequat enim officia anim ipsum aliqua excepteur qui sint. Duis sint do culpa adipisicing dolor adipisicing ea dolore aute nisi quis ullamco aliquip occaecat. Aute ut mollit amet ut culpa ipsum eiusmod veniam elit aute elit.
       .af-modal__footer

--- a/storybook/design-system/src/pages/organisms/modal/templates/modal-small.pug
+++ b/storybook/design-system/src/pages/organisms/modal/templates/modal-small.pug
@@ -4,7 +4,7 @@
       .af-modal__header
         h4.af-modal__header-title Titre de la modal
         button.af-modal__header-close-btn(type="button" aria-label="Close")
-          include ../../../style/icons/templates/close.pug
+          include ../../../guidelines/icones/templates/close.pug
       .af-modal__body
         p Reprehenderit sit quis aute nisi consequat consequat mollit. Commodo in aliquip consectetur nulla sit anim. Pariatur minim commodo enim ea eu laborum culpa laboris. Labore labore irure ipsum consequat enim officia anim ipsum aliqua excepteur qui sint. Duis sint do culpa adipisicing dolor adipisicing ea dolore aute nisi quis ullamco aliquip occaecat. Aute ut mollit amet.
       .af-modal__footer

--- a/storybook/design-system/src/pages/organisms/modal/templates/modal.pug
+++ b/storybook/design-system/src/pages/organisms/modal/templates/modal.pug
@@ -5,7 +5,7 @@
       .af-modal__header
         h4.af-modal__header-title Large Modal Title
         button.af-modal__header-close-btn(type="button" aria-label="Close")
-          include ../../../style/icons/templates/close.pug
+          include ../../../guidelines/icones/templates/close.pug
       .af-modal__body
         p Reprehenderit sit quis aute nisi consequat consequat mollit. Commodo in aliquip consectetur nulla sit anim. Pariatur minim commodo enim ea eu laborum culpa laboris. Labore labore irure ipsum consequat enim officia anim ipsum aliqua excepteur qui sint. Duis sint do culpa adipisicing dolor adipisicing ea dolore aute nisi quis ullamco aliquip occaecat. Aute ut mollit amet ut culpa ipsum eiusmod veniam elit aute elit.
       .af-modal__footer

--- a/storybook/design-system/src/pages/organisms/paging/templates/classic.pug
+++ b/storybook/design-system/src/pages/organisms/paging/templates/classic.pug
@@ -10,7 +10,7 @@
               select.af-form__input-select
                 each option in [5, 10, 15, 20]
                   option(value=option) #{option}
-              include ../../../style/icons/templates/menu-down.pug
+              include ../../../guidelines/icones/templates/menu-down.pug
             span.af-form__input-cmplt éléments
   .af-paging__pager
     include ../../../molecules/pager/templates/classic.pug

--- a/storybook/design-system/src/pages/organisms/panel/templates/panel-selection.pug
+++ b/storybook/design-system/src/pages/organisms/panel/templates/panel-selection.pug
@@ -21,6 +21,6 @@ article.af-panel.af-panel--selection
         small.af-panel__def-byyear Soit 768,00 € / an
   footer.af-panel__footer
     a.af-panel__footer-link(href="" role="button")
-      include ../../../style/icons/templates/cog.pug
+      include ../../../guidelines/icones/templates/cog.pug
       span  Ajustements
 

--- a/storybook/design-system/src/pages/organisms/panel/templates/panel.pug
+++ b/storybook/design-system/src/pages/organisms/panel/templates/panel.pug
@@ -5,5 +5,5 @@ article.af-panel
     p Lorem ipsum dolor sit amet, consectetur adipisicing elit. Itaque similique, quis aliquam temporibus velit ullam, quos quasi? Quod modi asperiores incidunt, velit repellendus, totam saepe quaerat voluptates cum quo facere.
   footer.af-panel__footer
     a.af-panel__footer-link(href="https://www.qwant.com" target="_blank" rel="noopener noreferrer")
-      include ../../../style/icons/templates/new-window.pug
+      include ../../../guidelines/icones/templates/new-window.pug
       span  Search with Qwant

--- a/storybook/design-system/src/pages/organisms/restitution/templates/restitution-double.pug
+++ b/storybook/design-system/src/pages/organisms/restitution/templates/restitution-double.pug
@@ -9,7 +9,7 @@
       .af-restitution__header-right
         .af-restitution__title
           a.af-link.af-link--hasIconLeft(href="#")
-            include ../../../style/icons/templates/pencil.pug
+            include ../../../guidelines/icones/templates/pencil.pug
             span.af-link__text Modifier
     section.af-restitution__content
       .col.col-sm-12.col-md-12.col-lg-12.col-xl-12

--- a/storybook/design-system/src/pages/organisms/restitution/templates/restitution-more.pug
+++ b/storybook/design-system/src/pages/organisms/restitution/templates/restitution-more.pug
@@ -10,7 +10,7 @@
         .af-restitution__header-right
           span.af-restitution__title
             a.af-link.af-link--hasIconLeft(href="#")
-              include ../../../style/icons/templates/pencil.pug
+              include ../../../guidelines/icones/templates/pencil.pug
               span.af-link__text Modifier
       section.af-restitution__content
         .col.col-sm-12.col-md-12.col-lg-12.col-xl-12
@@ -114,7 +114,7 @@
         .af-restitution__header-right
           span.af-restitution__title
             a.af-link.af-link--hasIconLeft(href="#")
-              include ../../../style/icons/templates/pencil.pug
+              include ../../../guidelines/icones/templates/pencil.pug
               span.af-link__text Modifier
       section.af-restitution__content
         .col.col-sm-12.col-md-12.col-lg-12.col-xl-12

--- a/storybook/design-system/src/pages/organisms/restitution/templates/restitution.pug
+++ b/storybook/design-system/src/pages/organisms/restitution/templates/restitution.pug
@@ -9,7 +9,7 @@
       .af-restitution__header-right
         span.af-restitution__title
           a.af-link.af-link--hasIconLeft(href="#")
-            include ../../../style/icons/templates/pencil.pug
+            include ../../../guidelines/icones/templates/pencil.pug
             span.af-link__text Modifier
     section.af-restitution__content
       .col.col-sm-12.col-md-12.col-lg-6.col-xl-6


### PR DESCRIPTION
## Related issue


### Description of the issue

Can't build the news design system due to broken references to pug templates.

```sh
[09:01:00] Plumber found unhandled error:
 Error in plugin "gulp-pug"
Message:
    /Users/a188dt/dev/react-toolkit/storybook/design-system/src/components/demo/demo.pug:5
    3|     -const classDisplayComponent = `${setClass('demo__display', modifier, true)}`
    4|     -const tmplPath = absTmpl !== '' ? absTmpl : tmpl!== '' ? `./src/pages${activePath}/templates/${tmpl}.pug` : ''
  > 5|     -const htmlCode = tmplPath !== '' ? pugg.compileFile(tmplPath, { pretty: true }) : 'No HTML'
    6|     -const sassCode = sassPath !== '' ? fs.readFileSync(`node_modules/@axa-fr/${sassPath}`, 'utf8') : 'No style'
    7|     block
    8|     article(class=classComponent)

ENOENT: no such file or directory, open 'src/pages/style/icons/templates/arrowthin-left.pug'
    at ./src/pages/atoms/button/templates/button-icon.pug line 3
Details:
    errno: -2
    syscall: open
    code: ENOENT
    path: /Users/a188dt/dev/react-toolkit/storybook/design-system/src/components/demo/demo.pug
```
### Person(s) for reviewing proposed changes

@samuel-gomez 

