### PR TITLE
fix(Form/Input/Date): Make the glyphicon clickable

### DIFF
--- a/packages/Form/Input/date/src/datepicker.scss
+++ b/packages/Form/Input/date/src/datepicker.scss
@@ -14,7 +14,6 @@ $border-radius-width: 3px;
     right: 1rem;
     top: 0.7rem;
     color: $color-dusty-gray;
-    z-index: 2;
     width: 17px;
   }
 


### PR DESCRIPTION
## Related issue

### Description of the issue

When you use the Form/Input/Date component, you are not able to click on the glyphicon in the input field. You have to click somewhere else in the input field.

### Person(s) for reviewing proposed changes

@gcruchon @guillaumechervet @guillaume-chervet @guillaumechervetaxa @samuel-gomez @samuel-gomez-axa @Cleclemi28 @youf-olivier @Gparquet

# Important

Before creating a pull request run unit tests

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```