### PR TITLE
build: drop support of old Node.js versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing to @axa-fr/react-toolkit
 
+## Prerequisite
+
+You must use a version of Node.js respecting the following rule `>=10.14.2` or `12.x` or `>=14`.
+
 ## Installation
 
 To get started with the repository:

--- a/package.json
+++ b/package.json
@@ -162,8 +162,7 @@
     "sass": "^1.26.5"
   },
   "engines": {
-    "node": ">=8.0.0 <12",
-    "yarn": ">=1.3.2"
+    "node": ">=10.14.2 || ^12 || >=14"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
Drop support of Node.js version not supported our dependencies:
- must be a LTS version
- jest minimum support is [10.14.2](https://github.com/facebook/jest/blob/master/package.json#L134)

Fixes #706 