### PR TITLE
feat(collapse): added onToggleCallback prop on CollapseCardBase

### DIFF
--- a/packages/collapse/src/Accordion.tsx
+++ b/packages/collapse/src/Accordion.tsx
@@ -25,10 +25,17 @@ export const AccordionBase = ({
   collapses,
 }: Props) => {
   const renderedChildren = React.Children.map(children, (child, index) => {
+    let mixCallback = handleToggle;
+    if(child.props.onToggle) {
+      mixCallback = (e: HeaderToggleElement) => {
+        handleToggle(e);
+        child.props.onToggle(e);
+      };
+    }
     return React.cloneElement(child, {
       ...child.props,
       index,
-      onToggle: handleToggle,
+      onToggle: mixCallback,
       collapse:
         collapses[index] !== undefined
           ? collapses[index]

--- a/packages/collapse/src/Collapse.stories.tsx
+++ b/packages/collapse/src/Collapse.stories.tsx
@@ -84,7 +84,7 @@ const AccordionStory = () => (
     classModifier={text('classModifier', '')}
     className={text('className', '')}
     onlyOne={boolean('onlyOne', true)}>
-    <CollapseCardBase collapse={false}>
+    <CollapseCardBase collapse={false} onToggle={action('onToggle')}>
       <CollapseCard.Header>
         {text(KNOBS_LABELS.collapse1.title, LABELS.collapse1.title)}
       </CollapseCard.Header>
@@ -94,7 +94,7 @@ const AccordionStory = () => (
       </CollapseCard.Body>
     </CollapseCardBase>
 
-    <CollapseCardBase>
+    <CollapseCardBase onToggle={action('onToggle')}>
       <CollapseCard.Header>
         {text(KNOBS_LABELS.collapse2.title, LABELS.collapse2.title)}
       </CollapseCard.Header>
@@ -103,7 +103,7 @@ const AccordionStory = () => (
       </CollapseCard.Body>
     </CollapseCardBase>
 
-    <CollapseCardBase collapse={false}>
+    <CollapseCardBase collapse={false} onToggle={action('onToggle')}>
       <CollapseCard.Header>
         {text(KNOBS_LABELS.collapse3.title, LABELS.collapse3.title)}
       </CollapseCard.Header>
@@ -119,7 +119,8 @@ const AccordionSingleStory = () => (
     classModifier={text('classModifier', '')}
     className={text('className', '')}
     onlyOne={boolean('onlyOne', true)}>
-    <CollapseCardBase id="idcollaspe1">
+    <CollapseCardBase
+      id="idcollaspe1">
       <CollapseCard.Header>
         {text(KNOBS_LABELS.collapse1.title, LABELS.collapse1.title)}
       </CollapseCard.Header>


### PR DESCRIPTION
## Related issue

### Reference to the issue

Fix #721 

### Description of the issue

Accordion rewrites onToggle for CollapseCardBase, a possible solution is to add a callback function props  that would be called after onToggle

### Person(s) for reviewing proposed changes

`You can add @mention here`

# Important

Before creating a pull request run unit tests

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```