### PR TITLE
fix(CheckBox): focus through TAB key with toggle mode

### DIFF
--- a/packages/Form/Input/checkbox/src/checkbox.scss
+++ b/packages/Form/Input/checkbox/src/checkbox.scss
@@ -33,7 +33,6 @@
   &__input-checkbox {
     position: absolute;
     z-index: -1;
-    visibility: hidden;
 
     &:checked + .af-form__label {
       .af-form__indicator {
@@ -79,7 +78,8 @@
   }
 
   /* Custom */
-  &__checkbox-custom, &__checkbox-toggle {
+  &__checkbox-custom,
+  &__checkbox-toggle {
     display: inline-flex;
     align-items: center;
     margin: 0 0.3rem 0.3rem 0;
@@ -107,7 +107,6 @@
     .af-form__input-checkbox {
       position: absolute;
       z-index: -1;
-      visibility: hidden;
 
       &:checked + .af-form__label {
         background-color: $color-azur;
@@ -186,7 +185,7 @@
       border-radius: 100%;
       transition: 0.4s;
     }
-    .af-form__description{
+    .af-form__description {
       display: none;
     }
     .af-form__input-checkbox {
@@ -218,12 +217,12 @@
         box-shadow: none;
       }
     }
-    &--error{
+    &--error {
       .af-form__label {
         background-color: $color-red-error;
       }
     }
-    &--warning{
+    &--warning {
       .af-form__label {
         background-color: $color-orange-dark;
       }


### PR DESCRIPTION
## Related issue
[CheckboxInput] Unable to navigate through Tab key in toggle mode with tabindex
### Reference to the issue
#582 
### Description of the issue

With the CheckboxInput component in toggle mode, the navigation through "Tab" key does not seem to be working as the input is hidden behind the rendered Toggle button.

### Person(s) for reviewing proposed changes
@samuel-gomez @arnaudforaison @xballoy 

# Important

Before creating a pull request run unit tests

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```