### PR TITLE
build: force csstype to version ^3.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11833,9 +11833,9 @@
       }
     },
     "csstype": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-      "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.4.tgz",
+      "integrity": "sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA==",
       "dev": true
     },
     "currently-unhandled": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "concurrently": "^5.3.0",
     "cross-env": "^7.0.2",
     "css-loader": "^5.0.0",
+    "csstype": "^3.0.4",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.5",
     "enzyme-to-json": "^3.6.1",


### PR DESCRIPTION
When we run `npm test -- --coverage` we have the following issue:

```
packages/Modal/default/src/Div.tsx:8:46 - error TS2322: Type '{ ref?: LegacyRef<HTMLDivElement>; key?: Key; defaultChecked?: boolean; defaultValue?: string | number | readonly string[]; suppressContentEditableWarning?: boolean; ... 250 more ...; onTransitionEndCapture?: (event: TransitionEvent<...>) => void; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'.
      Type '{ ref?: LegacyRef<HTMLDivElement>; key?: Key; defaultChecked?: boolean; defaultValue?: string | number | readonly string[]; suppressContentEditableWarning?: boolean; ... 250 more ...; onTransitionEndCapture?: (event: TransitionEvent<...>) => void; }' is not assignable to type 'HTMLAttributes<HTMLDivElement>'.
        The types of 'style.overflowX' are incompatible between these types.
          Type 'import("/home/vsts/work/1/s/packages/Modal/default/node_modules/csstype/index").Property.OverflowX' is not assignable to type 'import("/home/vsts/work/1/s/node_modules/csstype/index").Property.OverflowX'.
            Type '"clip"' is not assignable to type 'OverflowX'.
```

The issue is due to type incompatibility between csstype 3.0.3 and csstype 3.0.4 probably because of [this change](https://github.com/frenic/csstype/commit/c3cdae00ea996566d1c02513eac45bb47e78f64c#diff-62bba1377111a574be88b153f68d211eb304943484e20b3249edc957074d7903R4674).

Our dependency graph is the following:
```
.
└─ @types/react ^16.9.53 --> @types/react 16.9.54
        └─ csstype ^3.0.2 --> resolved as csstype 3.0.3
packages/Modal/default
└─ @types/react-modal: ^3.10.6
        └─ @types/react: * --> resolved as @types/react 16.9.54
                └─ csstype ^3.0.2 --> resolved as csstype 3.0.4
```

I do not understand why csstype is not **always** resolved as csstype 3.0.4 but in order to fix it I added `csstype: ^3.0.4` in the root package.json to force it.