### PR TITLE
build: exclude lerna from prettier check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,5 +5,6 @@ node_modules
 package-lock.json
 
 CHANGELOG.md
+lerna.json
 packages/all/src/bootstrap/af-components.template.scss
 packages/all/src/bootstrap/af-toolkit-core.template.scss


### PR DESCRIPTION
Exclude `lerna.json` from Prettier check to fix CI on master.