### PR TITLE
build: fix CI job condition

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ steps:
 
   - script: npm run publish -- $(Npm.Publish.Version) --exact --yes --concurrency 1 --force-publish
     displayName: 'lerna publish latest'
-    condition: and(succeeded(), notIn(variables['Npm.Publish.Version'], 'none', 'premajor', 'preminor', 'prepatch', 'prerelease')
+    condition: and(succeeded(), notIn(variables['Npm.Publish.Version'], 'none', 'premajor', 'preminor', 'prepatch', 'prerelease'))
 
   - script: npm run publish -- $(Npm.Publish.Version) --dist-tag next --exact --yes --concurrency 1 --force-publish
     displayName: 'lerna publish next'


### PR DESCRIPTION
Fix issue on CI
```
Job Job: Step specifies condition and(succeeded(), notIn(variables['Npm.Publish.Version'], 'none', 'premajor', 'preminor', 'prepatch', 'prerelease') which is not valid. Reason: Unclosed function: 'and'. Located at position 1 within expression: and(succeeded(), notIn(variables['Npm.Publish.Version'], 'none', 'premajor', 'preminor', 'prepatch', 'prerelease'). For more help, refer to https://go.microsoft.com/fwlink/?linkid=842996
```