### PR TITLE
feat: allow react element on inputs labels

### DIFF
--- a/packages/Form/Input/text/src/TextInput.stories.js
+++ b/packages/Form/Input/text/src/TextInput.stories.js
@@ -114,6 +114,44 @@ const TextInputErrorStory = () => (
   </form>
 );
 
+const richLabel = (
+  <span>
+    Place name <i>optional</i>
+  </span>
+);
+
+const TextRichLabelStory = () => (
+  <form className="af-form" name="myform">
+    <TextInput
+      id={text('id', 'uniqueid')}
+      label={richLabel}
+      name={text('name', 'placeName')}
+      onChange={action('onChange')}
+      value={text('value', '')}
+      helpMessage={text('helpMessage', 'Enter the place name, ex : Webcenter')}
+      placeholder={text('placeholder', '')}
+      message={text('message', 'Le champ est obligatoire')}
+      messageType={select('messageType', MessageTypes, MessageTypes.error)}
+      forceDisplayMessage={boolean('forceDisplayMessage', true)}
+      readOnly={boolean('readOnly', false)}
+      disabled={boolean('disabled', false)}
+      isVisible={boolean('isVisible', true)}
+      className={text('className', '')}
+      tabIndex={text('tabIndex', '')}
+      autoFocus={boolean('autoFocus', false)}
+      classNameContainerLabel={text(
+        'classNameContainerLabel',
+        Constants.defaultProps.classNameContainerLabel
+      )}
+      classNameContainerInput={text(
+        'classNameContainerInput',
+        Constants.defaultProps.classNameContainerInput
+      )}>
+      <HelpButton>tooltip avec du text</HelpButton>
+    </TextInput>
+  </form>
+);
+
 const TextStory = () => (
   <form className="af-form" name="myform">
     <FieldForm
@@ -254,3 +292,4 @@ stories.add('Text Disabled', TextDisabledStory);
 stories.add('TextInput', TextInputStory);
 stories.add('TextInput Required', TextInputStoryRequired);
 stories.add('TextInput Error', TextInputErrorStory);
+stories.add('TextInput Rich Label', TextRichLabelStory);

--- a/packages/Form/core/src/Field.js
+++ b/packages/Form/core/src/Field.js
@@ -7,7 +7,7 @@ import FieldForm from './FieldForm';
 import Constants from './FieldConstants';
 
 const propTypes = {
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
   children: PropTypes.node.isRequired,
   message: PropTypes.string,
   messageType: PropTypes.oneOf([

--- a/packages/Form/core/src/FieldConstants.js
+++ b/packages/Form/core/src/FieldConstants.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import MessageTypes from './MessageTypes';
 
 const propTypes = {
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   helpMessage: PropTypes.string,


### PR DESCRIPTION
Simple use Case : Permettre d'ajouter plus que du texte dans les labels.

Cf exemple ajouté dans le storybook : 

![image](https://user-images.githubusercontent.com/40664502/100236385-e2cc3680-2f2d-11eb-9aaf-95720489076c.png)

Pour le moment on peut le faire mais ça log un warning. 