### PR TITLE
feat(all): allow to import a specific component instead of all components

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,6 @@ tsconfig.json
 tsconfig.dev.json
 tsconfig.test.json
 package.json
+
+# react-toolkit-all
+packages/all/component

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,5 +6,8 @@ package-lock.json
 
 CHANGELOG.md
 lerna.json
+
+# react-toolkit-all
 packages/all/src/bootstrap/af-components.template.scss
 packages/all/src/bootstrap/af-toolkit-core.template.scss
+packages/all/component

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,7 @@
 
 - [From version 1.x to 2.0.x](#from-version-1x-to-20x)
   - [Date Input](#date-input)
+  - [All](#package-react-toolkit-all)
 
 # From version 1.x to 2.0.x
 
@@ -32,4 +33,13 @@ In 2.0.x
   value={new Date('11-26-2017')}
   format="dd/MM/yyyyy"
 />
+```
+
+## Package `react-toolkit-all`
+
+The component `Title` (from `@axa-fr/react-toolkit-layout-header`) has been renamed to `HeaderTitle` to add `@axa-fr/react-toolkit-title` to the `@axa-fr/react-toolkit-all` package.
+
+```diff
+- import { Title } from '@axa-fr/react-toolkit-all';
++ import { HeaderTitle } from '@axa-fr/react-toolkit-all';
 ```

--- a/README.md
+++ b/README.md
@@ -15,40 +15,54 @@
 
 ## About
 
-A set of independent components. Awesome library based on HTML and CSS using BEM convention with the JavaScript ReactJS implementation. Each components are autonomous and extensible. Pick and use only what you need!
+A set of independent components. Awesome library based on HTML and CSS using BEM convention with the JavaScript ReactJS implementation. Each component is autonomous and extensible. Pick and use only what you need!
 
 **How _React-toolkit_ does CSS isolation?**
 
-Only by using [BEM (Block Element Modifier)](http://getbem.com) CSS convention. No need of the intricate technologies, just pragatism.
+Only by using [BEM (Block Element Modifier)](http://getbem.com) CSS convention. No need for intricate technologies, just pragmatism.
 
-Components are simple to use (just drag and drog it), simple to customize (by using CSS modifier) to your own need. Each component may evaluate internally (HTML, CSS, JS) and minimize an impact on your application.
+Components are simple to use (just drag and drop it), simple to customize (by using CSS modifier) to your own need. Each component may evaluate internally (HTML, CSS, JS) and minimize any impact on your application.
 
-You can easily build a new app from scratch or integrate some component into existing application.
+You can easily build a new app from scratch or integrate some components into an existing application.
 
 [html+css documentation website](https://axaguildev.github.io?target=react_toolkit_storybook)
 [react storybook website](https://axaguildev.github.io?target=react_toolkit_design)
 
 ## Getting Started
 
-Install what you need
+You can either install everything and use only what you need. If you do that you will be able to use tree shaking to have a smaller bundle.
+However, you will need to import all the styles and not only the style related to your component.
+
+```sh
+npm install @axa-fr/react-toolkit-all --save
+```
+
+```javascript
+import React from 'react';
+
+// Load only the component alert (smaller bundle size)
+import { Alert } from '@axa-fr/react-toolkit-all/component/alert';
+
+// Load all the toolkit (bigger bundle size)
+import { Alert } from '@axa-fr/react-toolkit-all';
+
+import '@axa-fr/react-toolkit-all/dist/style/af-toolkit-core.scss';
+
+const MyAlertComponent = () => <Alert icon="ok" title="This is an alert" />;
+```
+
+Or you can install only the components you need:
 
 ```sh
 npm install @axa-fr/react-toolkit-alert --save
 ```
-
-Use only what you need
 
 ```javascript
 import React from 'react';
 import Alert from '@axa-fr/react-toolkit-alert';
 import '@axa-fr/react-toolkit-alert/dist/alert.scss';
 
-const MyAlertComponent => () => (
-<Alert
-    icon="ok"
-    title="This is an alert"
-  />
-)
+const MyAlertComponent = () => <Alert icon="ok" title="This is an alert" />;
 ```
 
 ## Packages
@@ -113,7 +127,7 @@ Each component should be autonomous (HTML + CSS + JS) and extensible.
 
 - React :
   - Components are stateless by default
-  - Some Higher Order Components (HOC) are stateful but feel free to use the stateless one if it fits your use case
+  - Some Higher-Order Components (HOC) are stateful but feel free to use the stateless one if it fits your use case
   - [React documentation](https://axaguildev.github.io?target=react_toolkit_design)
 
 ## List of supported browsers

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@axa-fr/react-toolkit",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "autoprefixer": "^10.0.1",
         "clean-css": "^4.2.3",

--- a/packages/all/.gitignore
+++ b/packages/all/.gitignore
@@ -1,0 +1,1 @@
+component

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@axa-fr/react-toolkit-all",
   "version": "1.4.0-alpha.1",
-  "main": "dist/index.js",
+  "main": "component/index.js",
   "jsnext:main": "src/index.js",
   "private": false,
   "scripts": {
-    "prepare": "node ../../scripts/prepare.js"
+    "prepare": "node ../../scripts/prepare-all.js"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/packages/all/src/action.js
+++ b/packages/all/src/action.js
@@ -1,0 +1,1 @@
+export { default as Action } from '@axa-fr/react-toolkit-action';

--- a/packages/all/src/alert.js
+++ b/packages/all/src/alert.js
@@ -1,0 +1,1 @@
+export { default as Alert } from '@axa-fr/react-toolkit-alert';

--- a/packages/all/src/badge.js
+++ b/packages/all/src/badge.js
@@ -1,0 +1,1 @@
+export { default as Badge } from '@axa-fr/react-toolkit-badge';

--- a/packages/all/src/button.js
+++ b/packages/all/src/button.js
@@ -1,0 +1,1 @@
+export { default as Button } from '@axa-fr/react-toolkit-button';

--- a/packages/all/src/collapse.js
+++ b/packages/all/src/collapse.js
@@ -1,0 +1,6 @@
+export {
+  CollapseCard,
+  CollapseCardBase,
+  Accordion,
+  AccordionBase,
+} from '@axa-fr/react-toolkit-collapse';

--- a/packages/all/src/core.js
+++ b/packages/all/src/core.js
@@ -1,0 +1,5 @@
+export {
+  ClassManager,
+  InputManager,
+  Constants,
+} from '@axa-fr/react-toolkit-core';

--- a/packages/all/src/form-core.js
+++ b/packages/all/src/form-core.js
@@ -1,0 +1,15 @@
+export {
+  FormClassManager,
+  FieldConstants,
+  Field,
+  FieldInput,
+  FieldForm,
+  HelpMessage,
+  MessageTypes,
+  FieldError,
+  InputConstants,
+  Input,
+  InputList,
+  withInput,
+  omit,
+} from '@axa-fr/react-toolkit-form-core';

--- a/packages/all/src/form-filter-inline.js
+++ b/packages/all/src/form-filter-inline.js
@@ -1,0 +1,1 @@
+export { default as FilterInline } from '@axa-fr/react-toolkit-form-filter-inline';

--- a/packages/all/src/form-filter.js
+++ b/packages/all/src/form-filter.js
@@ -1,0 +1,1 @@
+export { default as Filter } from '@axa-fr/react-toolkit-form-filter';

--- a/packages/all/src/form-input-card.js
+++ b/packages/all/src/form-input-card.js
@@ -1,0 +1,9 @@
+export {
+  CardGroupRadio,
+  CardGroupCheckbox,
+  Card,
+  CardMeta,
+  CardContent,
+  CardHeader,
+  CardFooter,
+} from '@axa-fr/react-toolkit-form-input-card';

--- a/packages/all/src/form-input-checkbox.js
+++ b/packages/all/src/form-input-checkbox.js
@@ -1,0 +1,6 @@
+export {
+  CheckboxItem,
+  CheckboxInput,
+  Checkbox,
+  CheckboxModes,
+} from '@axa-fr/react-toolkit-form-input-checkbox';

--- a/packages/all/src/form-input-choice.js
+++ b/packages/all/src/form-input-choice.js
@@ -1,0 +1,1 @@
+export { ChoiceInput, Choice } from '@axa-fr/react-toolkit-form-input-choice';

--- a/packages/all/src/form-input-date-phone.js
+++ b/packages/all/src/form-input-date-phone.js
@@ -1,0 +1,4 @@
+export {
+  DatePhone,
+  DatePhoneInput,
+} from '@axa-fr/react-toolkit-form-input-date-phone';

--- a/packages/all/src/form-input-date.js
+++ b/packages/all/src/form-input-date.js
@@ -1,0 +1,1 @@
+export { CustomDate, DateInput } from '@axa-fr/react-toolkit-form-input-date';

--- a/packages/all/src/form-input-file.js
+++ b/packages/all/src/form-input-file.js
@@ -1,0 +1,6 @@
+export {
+  FileInput,
+  File,
+  FileTable,
+  FileLine,
+} from '@axa-fr/react-toolkit-form-input-file';

--- a/packages/all/src/form-input-number.js
+++ b/packages/all/src/form-input-number.js
@@ -1,0 +1,1 @@
+export { NumberInput, Number } from '@axa-fr/react-toolkit-form-input-number';

--- a/packages/all/src/form-input-pass.js
+++ b/packages/all/src/form-input-pass.js
@@ -1,0 +1,1 @@
+export { Pass, PassInput } from '@axa-fr/react-toolkit-form-input-pass';

--- a/packages/all/src/form-input-radio.js
+++ b/packages/all/src/form-input-radio.js
@@ -1,0 +1,6 @@
+export {
+  RadioItem,
+  RadioInput,
+  Radio,
+  RadioModes,
+} from '@axa-fr/react-toolkit-form-input-radio';

--- a/packages/all/src/form-input-select-multi.js
+++ b/packages/all/src/form-input-select-multi.js
@@ -1,0 +1,4 @@
+export {
+  MultiSelectInput,
+  MultiSelect,
+} from '@axa-fr/react-toolkit-form-input-select-multi';

--- a/packages/all/src/form-input-select.js
+++ b/packages/all/src/form-input-select.js
@@ -1,0 +1,6 @@
+export {
+  Select,
+  SelectBase,
+  SelectModes,
+  SelectInput,
+} from '@axa-fr/react-toolkit-form-input-select';

--- a/packages/all/src/form-input-slider.js
+++ b/packages/all/src/form-input-slider.js
@@ -1,0 +1,1 @@
+export { Slider, SliderInput } from '@axa-fr/react-toolkit-form-input-slider';

--- a/packages/all/src/form-input-switch.js
+++ b/packages/all/src/form-input-switch.js
@@ -1,0 +1,1 @@
+export { Switch, SwitchInput } from '@axa-fr/react-toolkit-form-input-switch';

--- a/packages/all/src/form-input-text.js
+++ b/packages/all/src/form-input-text.js
@@ -1,0 +1,1 @@
+export { TextInput, Text } from '@axa-fr/react-toolkit-form-input-text';

--- a/packages/all/src/form-input-textarea.js
+++ b/packages/all/src/form-input-textarea.js
@@ -1,0 +1,4 @@
+export {
+  Textarea,
+  TextareaInput,
+} from '@axa-fr/react-toolkit-form-input-textarea';

--- a/packages/all/src/form-steps.js
+++ b/packages/all/src/form-steps.js
@@ -1,0 +1,6 @@
+export {
+  Steps,
+  StepBase,
+  Step,
+  StepModes,
+} from '@axa-fr/react-toolkit-form-steps';

--- a/packages/all/src/form-summary.js
+++ b/packages/all/src/form-summary.js
@@ -1,0 +1,1 @@
+export { Summary } from '@axa-fr/react-toolkit-form-summary';

--- a/packages/all/src/help.js
+++ b/packages/all/src/help.js
@@ -1,0 +1,1 @@
+export { default as HelpButton } from '@axa-fr/react-toolkit-help';

--- a/packages/all/src/highlight.js
+++ b/packages/all/src/highlight.js
@@ -1,0 +1,1 @@
+export { default as Highlight } from '@axa-fr/react-toolkit-highlight';

--- a/packages/all/src/icon.js
+++ b/packages/all/src/icon.js
@@ -1,0 +1,1 @@
+export { default as Icon } from '@axa-fr/react-toolkit-icon';

--- a/packages/all/src/index.js
+++ b/packages/all/src/index.js
@@ -1,133 +1,44 @@
-export { TextInput, Text } from '@axa-fr/react-toolkit-form-input-text';
-export { CustomDate, DateInput } from '@axa-fr/react-toolkit-form-input-date';
-export {
-  DatePhone,
-  DatePhoneInput,
-} from '@axa-fr/react-toolkit-form-input-date-phone';
-export { ChoiceInput, Choice } from '@axa-fr/react-toolkit-form-input-choice';
-export {
-  Select,
-  SelectBase,
-  SelectModes,
-  SelectInput,
-} from '@axa-fr/react-toolkit-form-input-select';
-export {
-  MultiSelectInput,
-  MultiSelect,
-} from '@axa-fr/react-toolkit-form-input-select-multi';
-export {
-  FileInput,
-  File,
-  FileTable,
-  FileLine,
-} from '@axa-fr/react-toolkit-form-input-file';
-export { Slider, SliderInput } from '@axa-fr/react-toolkit-form-input-slider';
-export {
-  Textarea,
-  TextareaInput,
-} from '@axa-fr/react-toolkit-form-input-textarea';
-export {
-  CheckboxItem,
-  CheckboxInput,
-  Checkbox,
-  CheckboxModes,
-} from '@axa-fr/react-toolkit-form-input-checkbox';
-export {
-  RadioItem,
-  RadioInput,
-  Radio,
-  RadioModes,
-} from '@axa-fr/react-toolkit-form-input-radio';
-export { Summary } from '@axa-fr/react-toolkit-form-summary';
-export {
-  Steps,
-  StepBase,
-  Step,
-  StepModes,
-} from '@axa-fr/react-toolkit-form-steps';
-export {
-  FormClassManager,
-  FieldConstants,
-  Field,
-  FieldInput,
-  FieldForm,
-  HelpMessage,
-  MessageTypes,
-  FieldError,
-  InputConstants,
-  Input,
-  InputList,
-  withInput,
-  omit,
-} from '@axa-fr/react-toolkit-form-core';
-export { NumberInput, Number } from '@axa-fr/react-toolkit-form-input-number';
-export { Pass, PassInput } from '@axa-fr/react-toolkit-form-input-pass';
-export {
-  CardGroupRadio,
-  CardGroupCheckbox,
-  Card,
-  CardMeta,
-  CardContent,
-  CardHeader,
-  CardFooter,
-} from '@axa-fr/react-toolkit-form-input-card';
-export { Switch, SwitchInput } from '@axa-fr/react-toolkit-form-input-switch';
-export { Footer } from '@axa-fr/react-toolkit-layout-footer';
-export {
-  FooterClient,
-  FooterClientList,
-  FooterClientItem,
-  LanguageSelection,
-  SocialNetwork,
-} from '@axa-fr/react-toolkit-layout-footer-client';
-export {
-  Header,
-  Infos,
-  Name,
-  NavBar,
-  NavBarBase,
-  NavBarItem,
-  NavBarItemBase,
-  NavBarItemLink,
-  Title,
-  ToggleButton,
-  User,
-} from '@axa-fr/react-toolkit-layout-header';
-export { Items, Pager, Paging } from '@axa-fr/react-toolkit-table';
-export { default as Table } from '@axa-fr/react-toolkit-table';
-export {
-  CollapseCard,
-  CollapseCardBase,
-  Accordion,
-  AccordionBase,
-} from '@axa-fr/react-toolkit-collapse';
-export { default as Loader } from '@axa-fr/react-toolkit-loader';
-export { LoaderModes } from '@axa-fr/react-toolkit-loader';
-export { default as HelpButton } from '@axa-fr/react-toolkit-help';
-export { default as Popover } from '@axa-fr/react-toolkit-popover';
-export {
-  PopoverBase,
-  PopoverModes,
-  PopoverPlacements,
-} from '@axa-fr/react-toolkit-popover';
-export { default as Modal } from '@axa-fr/react-toolkit-modal-default';
-export { default as BooleanModal } from '@axa-fr/react-toolkit-modal-boolean';
-export { default as Action } from '@axa-fr/react-toolkit-action';
-export { default as Alert } from '@axa-fr/react-toolkit-alert';
-export { default as Tabs } from '@axa-fr/react-toolkit-tabs';
-export { default as Badge } from '@axa-fr/react-toolkit-badge';
-export { default as Button } from '@axa-fr/react-toolkit-button';
-export {
-  ClassManager,
-  InputManager,
-  Constants,
-} from '@axa-fr/react-toolkit-core';
-export { default as Icon } from '@axa-fr/react-toolkit-icon';
-export {
-  ArticleRestitution,
-  HeaderRestitution,
-  SectionRestitution,
-  SectionRestitutionColumn,
-  SectionRestitutionRow,
-  Restitution,
-} from '@axa-fr/react-toolkit-restitution';
+export * from './action';
+export * from './alert';
+export * from './badge';
+export * from './button';
+export * from './collapse';
+export * from './core';
+export * from './form-core';
+export * from './form-filter';
+export * from './form-filter-inline';
+export * from './form-input-card';
+export * from './form-input-checkbox';
+export * from './form-input-choice';
+export * from './form-input-date';
+export * from './form-input-date-phone';
+export * from './form-input-file';
+export * from './form-input-number';
+export * from './form-input-pass';
+export * from './form-input-radio';
+export * from './form-input-select';
+export * from './form-input-select-multi';
+export * from './form-input-slider';
+export * from './form-input-switch';
+export * from './form-input-text';
+export * from './form-input-textarea';
+export * from './form-steps';
+export * from './form-summary';
+export * from './help';
+export * from './highlight';
+export * from './icon';
+export * from './layout-footer';
+export * from './layout-footer-client';
+export * from './layout-header';
+export * from './link';
+export * from './list';
+export * from './loader';
+export * from './modal-boolean';
+export * from './modal-default';
+export * from './panel';
+export * from './popover';
+export * from './restitution';
+export * from './status';
+export * from './table';
+export * from './tabs';
+export * from './title';

--- a/packages/all/src/layout-footer-client.js
+++ b/packages/all/src/layout-footer-client.js
@@ -1,0 +1,7 @@
+export {
+  FooterClient,
+  FooterClientList,
+  FooterClientItem,
+  LanguageSelection,
+  SocialNetwork,
+} from '@axa-fr/react-toolkit-layout-footer-client';

--- a/packages/all/src/layout-footer.js
+++ b/packages/all/src/layout-footer.js
@@ -1,0 +1,1 @@
+export { Footer } from '@axa-fr/react-toolkit-layout-footer';

--- a/packages/all/src/layout-header.js
+++ b/packages/all/src/layout-header.js
@@ -1,0 +1,13 @@
+export {
+  Header,
+  Infos,
+  Name,
+  NavBar,
+  NavBarBase,
+  NavBarItem,
+  NavBarItemBase,
+  NavBarItemLink,
+  Title as HeaderTitle,
+  ToggleButton,
+  User,
+} from '@axa-fr/react-toolkit-layout-header';

--- a/packages/all/src/link.js
+++ b/packages/all/src/link.js
@@ -1,0 +1,1 @@
+export { default as Link } from '@axa-fr/react-toolkit-link';

--- a/packages/all/src/list.js
+++ b/packages/all/src/list.js
@@ -1,0 +1,1 @@
+export { default as List } from '@axa-fr/react-toolkit-list';

--- a/packages/all/src/loader.js
+++ b/packages/all/src/loader.js
@@ -1,0 +1,1 @@
+export { default as Loader, LoaderModes } from '@axa-fr/react-toolkit-loader';

--- a/packages/all/src/modal-boolean.js
+++ b/packages/all/src/modal-boolean.js
@@ -1,0 +1,1 @@
+export { default as BooleanModal } from '@axa-fr/react-toolkit-modal-boolean';

--- a/packages/all/src/modal-default.js
+++ b/packages/all/src/modal-default.js
@@ -1,0 +1,1 @@
+export { default as Modal } from '@axa-fr/react-toolkit-modal-default';

--- a/packages/all/src/panel.js
+++ b/packages/all/src/panel.js
@@ -1,0 +1,1 @@
+export { default as Panel } from '@axa-fr/react-toolkit-panel';

--- a/packages/all/src/popover.js
+++ b/packages/all/src/popover.js
@@ -1,0 +1,6 @@
+export {
+  default as Popover,
+  PopoverBase,
+  PopoverModes,
+  PopoverPlacements,
+} from '@axa-fr/react-toolkit-popover';

--- a/packages/all/src/restitution.js
+++ b/packages/all/src/restitution.js
@@ -1,0 +1,8 @@
+export {
+  ArticleRestitution,
+  HeaderRestitution,
+  SectionRestitution,
+  SectionRestitutionColumn,
+  SectionRestitutionRow,
+  Restitution,
+} from '@axa-fr/react-toolkit-restitution';

--- a/packages/all/src/status.js
+++ b/packages/all/src/status.js
@@ -1,0 +1,1 @@
+export { default as Status } from '@axa-fr/react-toolkit-status';

--- a/packages/all/src/table.js
+++ b/packages/all/src/table.js
@@ -1,0 +1,6 @@
+export {
+  default as Table,
+  Items,
+  Pager,
+  Paging,
+} from '@axa-fr/react-toolkit-table';

--- a/packages/all/src/tabs.js
+++ b/packages/all/src/tabs.js
@@ -1,0 +1,1 @@
+export { default as Tabs } from '@axa-fr/react-toolkit-tabs';

--- a/packages/all/src/title.js
+++ b/packages/all/src/title.js
@@ -1,0 +1,1 @@
+export { default as Title } from '@axa-fr/react-toolkit-title';

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -2,7 +2,7 @@ const chalk = require('chalk');
 const find = require('find');
 const rimraf = require('rimraf');
 
-const { packages, dist } = require('./config');
+const { packages, dist, allPackage, componentDistAll } = require('./config');
 
 const log = (prefix, message, inverse) => {
   const darkGray = '#111111';
@@ -31,11 +31,19 @@ const logFinished = (prefix, inverse = false) =>
 
 const getDistFolders = () => {
   try {
-    return find
-      .dirSync(/dist/g, packages)
+    const distExceptAll = find
+      .dirSync(new RegExp(dist, 'g'), packages)
       .filter(
         (dirPath) => !dirPath.includes('node_modules') && dirPath.endsWith(dist)
       );
+    const distComponentAll = find
+      .dirSync(new RegExp(componentDistAll, 'g'), allPackage)
+      .filter(
+        (dirPath) =>
+          !dirPath.includes('node_modules') &&
+          dirPath.endsWith(componentDistAll)
+      );
+    return [].concat(distExceptAll, distComponentAll);
   } catch (err) {
     console.error(err);
   }
@@ -47,6 +55,7 @@ const getDistFolders = () => {
 try {
   logStart('Clean all dist');
   const allDistFolders = getDistFolders() || [];
+  console.log('Folders to remove: ', allDistFolders);
   allDistFolders.map((distFolder) => rimraf.sync(distFolder));
 } catch (err) {
   console.error(err);

--- a/scripts/compile-js.js
+++ b/scripts/compile-js.js
@@ -2,17 +2,18 @@
 const fs = require('fs');
 const path = require('path');
 const shell = require('shelljs');
+const { src, dist } = require('./config');
 
-function getCommand(watch) {
+function getCommand(watch, outDir) {
   const babel = path.join(__dirname, '..', 'node_modules', '.bin', 'babel');
 
   const args = [
     '--root-mode upward',
-    './src --out-dir ./dist',
-    '--ignore "./src/**/*.stories.js","./src/**/*.spec.js",".src/__snapshots__"',
-    '--source-maps',
-    '--copy-files',
-    '--no-copy-ignored',
+    src,
+    `--out-dir ${outDir}`,
+    '--source-maps true',
+    '--extensions ".js,.ts,.tsx"',
+    '--ignore "**/*.spec.js,**/*.spec.ts,**/*.spec.tsx,**/*.stories.js,**/*.stories.ts,**/*.stories.tsx"',
   ];
 
   if (watch) {
@@ -33,14 +34,19 @@ function handleExit(code, errorCallback) {
 }
 
 function babelify(options = {}) {
-  const { watch = false, silent = false, errorCallback } = options;
+  const {
+    watch = false,
+    silent = false,
+    errorCallback,
+    outDir = dist,
+  } = options;
 
   if (!fs.existsSync('src')) {
     if (!silent) console.log('No src dir');
     return;
   }
 
-  const command = getCommand(watch);
+  const command = getCommand(watch, outDir);
   const { code } = shell.exec(command, { silent });
 
   handleExit(code, errorCallback);

--- a/scripts/compile-ts.js
+++ b/scripts/compile-ts.js
@@ -2,28 +2,21 @@
 const fs = require('fs');
 const path = require('path');
 const shell = require('shelljs');
+const { dist, tsConfigFile } = require('./config');
 
-function getCommand(watch) {
+function getCommand(watch, outDir) {
   const tsc = path.join(__dirname, '..', 'node_modules', '.bin', 'tsc');
 
-  const currentDirectory = process.cwd();
-  const output = path.join(currentDirectory, 'dist');
-  const tsconfig = path.join(currentDirectory, 'tsconfig.json');
   const args = [
-    `-p ${tsconfig}`,
-    `--outDir ${output}`,
-    '-d true',
-    `--declarationDir ${output}`,
-    '--declarationMap true',
-    '--listEmittedFiles true',
+    `-p ${tsConfigFile}`,
+    `--outDir ${outDir}`,
+    `--declarationDir ${outDir}`,
   ];
 
   if (watch) {
     args.push('-w');
   }
-  const command = `${tsc} ${args.join(' ')}`;
-
-  return command;
+  return `${tsc} ${args.join(' ')}`;
 }
 
 function handleExit(code, errorCallback) {
@@ -37,14 +30,19 @@ function handleExit(code, errorCallback) {
 }
 
 function tscfy(options = {}) {
-  const { watch = false, silent = false, errorCallback } = options;
-  const tsConfigFile = 'tsconfig.json';
+  const {
+    watch = false,
+    silent = false,
+    errorCallback,
+    outDir = dist,
+  } = options;
+
   if (!fs.existsSync(tsConfigFile)) {
     if (!silent) console.log(`No ${tsConfigFile}`);
     return;
   }
 
-  const command = getCommand(watch);
+  const command = getCommand(watch, outDir);
   const { code } = shell.exec(command, { silent });
 
   handleExit(code, errorCallback);

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -2,6 +2,7 @@ const path = require('path');
 
 const src = 'src';
 const dist = 'dist';
+const componentDistAll = 'component';
 const packages = 'packages';
 const core = 'core';
 const all = 'all';
@@ -9,10 +10,12 @@ const tasks = './scripts/tasks';
 const bootstrapModulesDistCss = 'node_modules/bootstrap/dist/css';
 const coreSrc = `${packages}/${core}/${src}`;
 const coreDist = `${packages}/${core}/${dist}`;
+const allPackage = `${packages}/${all}`;
 const allSrc = `${packages}/${all}/${src}`;
 const allDist = `${packages}/${all}/${dist}`;
 const assets = `${coreSrc}/common`;
 const bootstrap = `${coreSrc}/bootstrap`;
+const tsConfigFile = 'tsconfig.json';
 
 const autoprefixerConfig = {
   overrideBrowserslist: ['last 2 versions', '> 2%', 'IE 9'],
@@ -51,4 +54,7 @@ module.exports = {
   cleanCssConfig,
   autoprefixerConfig,
   bootstrapModulesDistCss,
+  tsConfigFile,
+  componentDistAll,
+  allPackage,
 };

--- a/scripts/prepare-all.js
+++ b/scripts/prepare-all.js
@@ -1,16 +1,12 @@
 /* eslint-disable no-console */
 require('shelljs');
 const chalk = require('chalk');
-const {
-  getPackageJson,
-  compile,
-  copyLicence,
-  copyReadmeToDist,
-} = require('./prepare-common');
+const { getPackageJson, compile, copyLicence } = require('./prepare-common');
+const { componentDistAll } = require('./config');
 
 const packageJson = getPackageJson();
 
-compile(packageJson);
+compile(packageJson, componentDistAll);
 
 copyLicence();
 

--- a/scripts/prepare-common.js
+++ b/scripts/prepare-common.js
@@ -1,0 +1,53 @@
+/* eslint-disable no-console */
+const path = require('path');
+const shell = require('shelljs');
+const chalk = require('chalk');
+const log = require('npmlog');
+const fs = require('fs');
+const { babelify } = require('./compile-js');
+const { tscfy } = require('./compile-ts');
+
+const getPackageJson = () => {
+  const modulePath = path.resolve('./');
+  // eslint-disable-next-line global-require,import/no-dynamic-require
+  return require(path.join(modulePath, 'package.json'));
+};
+
+const copyLicence = () => {
+  const licence = path.join(__dirname, '..', 'LICENSE');
+  shell.cp(licence, './');
+};
+
+const logError = (type, packageJson) => {
+  log.error(
+    `FAILED to compile ${type}: ${chalk.bold(
+      `${packageJson.name}@${packageJson.version}`
+    )}`
+  );
+};
+
+const copyReadmeToDist = () => {
+  const modulePath = path.resolve('./');
+  const readmePath = path.join(modulePath, 'README.md');
+  if (fs.existsSync(readmePath)) {
+    shell.cp(readmePath, path.join(modulePath, 'dist'));
+  }
+};
+
+const compile = (packageJson, outDir) => {
+  const hasTypescript = shell.find('src').some((it) => it.match(/\.tsx?$/));
+
+  if (hasTypescript) {
+    tscfy({ outDir, errorCallback: () => logError('ts', packageJson) });
+  } else {
+    babelify({ outDir, errorCallback: () => logError('js', packageJson) });
+  }
+};
+
+module.exports = {
+  compile,
+  copyLicence,
+  copyReadmeToDist,
+  logError,
+  getPackageJson,
+};


### PR DESCRIPTION
### TL;DR;

Add components' endpoint in `react-toolkit-all` to allow tree shaking.
We now have 3 options to import a component:

```
// Load the full toolkit
import { Button } from '@axa-fr/react-toolkit-all'

// Load only the component button (via all)
import { Button } from '@axa-fr/react-toolkit-all/component/button'

// Load only the component button
import Button from '@axa-fr/react-toolkit-button'
```

### More details...

I added the following missing packages in the `index.js` of the `react-toolkit-all` package:

- @axa-fr/react-toolkit-form-filter
- @axa-fr/react-toolkit-form-filter-inline
- @axa-fr/react-toolkit-highlight
- @axa-fr/react-toolkit-link
- @axa-fr/react-toolkit-list
- @axa-fr/react-toolkit-panel
- @axa-fr/react-toolkit-status
- @axa-fr/react-toolkit-title

There was a duplicate export so I had rename Title to HeaderTitle in `react-toolkit-layout-header` because it was a duplicate export with Title in title.
Maybe that `react-toolkit-title` wasn't in `react-toolkit-all` due to that issue ¯\_(ツ)_/¯

Because it feels weird to use to do the following in an application
```
import { Button } from '@axa-fr/react-toolkit-all/dist/button'
```

I renamed the `dist` folder to `component` for `react-toolkit-all` (not the other components) so we can do the following
```
import { Button } from '@axa-fr/react-toolkit-all/component/button'
```

With those new endpoints we have a huge bundle size improvement:

| Case                                                                                              | Size (KB) |
| ------------------------------------------------------------- | --------- |
| Empty CRA project                                                                        | 134,63    |
| Adding a button (using @axa-fr/react-toolkit-all)                       | 1040      |
| Adding a button (using @axa-fr/react-toolkit-all/component/button)   | 155,41    |
| Adding a button (using @axa-fr/react-toolkit-button)                | 155,21    |
