### PR TITLE
docs(migration): fixed a few typos and phrasings

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,11 +8,11 @@
 
 ## Date Input
 
-We updated the React DatePicker from 1.X to 3.X. The library no longer uses moment. Instead it uses DateFns as a dependency for date management. Therefore, the Date Input no longer uses moment object for the value, but a Javascript [Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date). Also, the onChange callback return a Date value instead of a moment Value.
+We updated the React DatePicker from 1.X to 3.X. The library no longer uses moment. Instead it uses DateFns as a dependency for date management. Therefore, the Date Input no longer uses moment object for the value, but a Javascript [Date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date). Also, the onChange callback returns a Date value instead of a moment value.
 
-The `locale` param also changed. It is a string which set the language of the component. You can find the full list on [DateFns's website](https://date-fns.org/v2.0.0-alpha.18/docs/I18n#supported-languages). This feature uses the [dynamic import](https://reactjs.org/docs/code-splitting.html#import) in order to import only the locales needed by the user. Be sure that your project is able to manage that with an approriate tool (like Webpack).
+The `locale` param also changed. It is a string which sets the language of the component. You can find the full list on [DateFns's website](https://date-fns.org/v2.0.0-alpha.18/docs/I18n#supported-languages). This feature uses the [dynamic import](https://reactjs.org/docs/code-splitting.html#import) in order to import only the locales needed by the user. Make sure that your project is compatible with code splitting. (_create-react-app_ does it out-of-the-box).
 
-We also added a `format` param which allow to specify the way to display value in viewvalue and in the field. He have to be a [unicode format](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table)
+We also added a `format` prop which allows to specify how `value` is formatted in `viewValue` and in the field. It has to be a [unicode format](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table)
 
 In 1.X:
 


### PR DESCRIPTION
I found a few issues with this guide, and this is my proposition to fix them.

The sentence with the dynamic import was weird, and CRA has it by default. Since it's most people's tool, i feel it's better to highlight that, rather than throwing a generic "make sure your tool does the job"

> param which allow to specify the way to display value in viewvalue and in the field

Still not sure what this was meant to say, especially the "viewvalue and in the field" part. But at least the sence feels less awkward to read in my opinion.