### PR TITLE
fix(modifier-hasiconRightOrLeft): put the correct version with camel …

### DIFF
--- a/packages/Form/Input/file/src/File.js
+++ b/packages/Form/Input/file/src/File.js
@@ -54,7 +54,7 @@ const File = ({
       <Button
         type="button"
         className="af-btn"
-        classModifier="file hasiconLeft"
+        classModifier="file hasIconLeft"
         onClick={open}
         disabled={disabled}>
         <i className={`glyphicon glyphicon-${icon}`} /> {label}

--- a/packages/action/src/button.scss
+++ b/packages/action/src/button.scss
@@ -58,11 +58,13 @@ $active-sort-table-th: $color-table-sorting !default;
     }
   }
 
-  &--hasiconLeft {
+  &--hasiconLeft,
+  &--hasIconLeft {
     @include hasIcon('left');
   }
 
-  &--hasiconRight {
+  &--hasiconRight,
+  &--hasIconRight {
     @include hasIcon('right');
   }
 
@@ -141,13 +143,15 @@ $active-sort-table-th: $color-table-sorting !default;
     border-bottom: none;
   }
 
-  &--reverse.af-btn--hasiconLeft {
+  &--reverse.af-btn--hasiconLeft,
+  &--reverse.af-btn--hasIconLeft {
     @include hasIcon('left');
 
     padding-right: 1.2rem;
   }
 
-  &--reverse.af-btn--hasiconRight {
+  &--reverse.af-btn--hasiconRight,
+  &--reverse.af-btn--hasIconRight {
     @include hasIcon('right');
 
     padding-left: 1.2rem;

--- a/packages/button/src/button.scss
+++ b/packages/button/src/button.scss
@@ -58,11 +58,13 @@ $active-sort-table-th: $color-table-sorting !default;
     }
   }
 
-  &--hasiconLeft {
+  &--hasiconLeft,
+  &--hasIconLeft {
     @include hasIcon('left');
   }
 
-  &--hasiconRight {
+  &--hasiconRight,
+  &--hasIconRight {
     @include hasIcon('right');
   }
 
@@ -141,13 +143,15 @@ $active-sort-table-th: $color-table-sorting !default;
     border-bottom: none;
   }
 
-  &--reverse.af-btn--hasiconLeft {
+  &--reverse.af-btn--hasiconLeft,
+  &--reverse.af-btn--hasIconLeft {
     @include hasIcon('left');
 
     padding-right: 1.2rem;
   }
 
-  &--reverse.af-btn--hasiconRight {
+  &--reverse.af-btn--hasiconRight,
+  &--reverse.af-btn--hasIconRight {
     @include hasIcon('right');
 
     padding-left: 1.2rem;

--- a/packages/link/src/link.scss
+++ b/packages/link/src/link.scss
@@ -10,6 +10,7 @@
     justify-content: flex-start;
 
     .glyphicon {
+      margin-right: 0.3rem;
       font-size: 0.9em;
       width: 17px;
     }
@@ -20,18 +21,6 @@
       .af-link__text {
         text-decoration: underline;
       }
-    }
-  }
-
-  &--hasIconLeft {
-    .glyphicon {
-      margin-right: 0.3rem;
-    }
-  }
-
-  &--hasIconRight {
-    .glyphicon {
-      margin-left: 0.3rem;
     }
   }
 }


### PR DESCRIPTION
…Case for modifiers #900

## Related issue

### Reference to the issue

`Here you can add link to related issue`
https://github.com/AxaGuilDEv/react-toolkit/issues/900


### Description of the issue

Avoid breaking change, I add a second modifier name with correct standard (camel case)  for hasIconLeft and hasIconRight.

### Person(s) for reviewing proposed changes

@johnmeunier @arnaudforaison @samuel-gomez 

