### PR TITLE
Feature/max length on form inputs

### DIFF
--- a/packages/Form/Input/number/src/Number.js
+++ b/packages/Form/Input/number/src/Number.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Input, InputConstants as Constants, withInput, omit } from '@axa-fr/react-toolkit-form-core';
+import {
+  Input,
+  InputConstants as Constants,
+  withInput,
+  omit,
+} from '@axa-fr/react-toolkit-form-core';
 import { InputManager } from '@axa-fr/react-toolkit-core';
 
 import parseValueToNumber from './NumberHelper';
@@ -21,6 +26,7 @@ const CustomNumber = props => {
     disabled,
     placeholder,
     inputRef,
+    maxLength,
     ...otherProps
   } = props;
   let currentViewValue = '';
@@ -44,6 +50,7 @@ const CustomNumber = props => {
       disabled={disabled}
       placeholder={placeholder}
       ref={inputRef}
+      maxLength={maxLength}
       {...omitProperties(otherProps)}
     />
   );

--- a/packages/Form/Input/number/src/NumberInput.js
+++ b/packages/Form/Input/number/src/NumberInput.js
@@ -46,6 +46,7 @@ const NumberInput = props => {
     onChange,
     readOnly,
     placeholder,
+    maxLength,
     ...otherProps
   } = props;
   const inputClassModifier = FormClassManager.getInputClassModifier(
@@ -86,6 +87,7 @@ const NumberInput = props => {
           disabled={disabled}
           placeholder={placeholder}
           classModifier={inputClassModifier}
+          maxLength={maxLength}
           {...otherProps}
         />
         {children}

--- a/packages/Form/Input/text/src/Text.js
+++ b/packages/Form/Input/text/src/Text.js
@@ -18,6 +18,7 @@ const Text = props => {
     placeholder,
     inputRef,
     onChange,
+    maxLength,
     ...otherProps
   } = props;
 
@@ -35,6 +36,7 @@ const Text = props => {
       disabled={disabled}
       placeholder={placeholder}
       ref={inputRef}
+      maxLength={maxLength}
       {...omitProperties(otherProps)}
     />
   );
@@ -49,9 +51,11 @@ const defaultProps = {
   className: defaultClassName,
 };
 
-const EnhancedComponent = withInput(defaultClassName, propTypes, defaultProps)(
-  Text
-);
+const EnhancedComponent = withInput(
+  defaultClassName,
+  propTypes,
+  defaultProps
+)(Text);
 
 EnhancedComponent.Clone = Input.Clone;
 EnhancedComponent.ContainerClassName = 'af-form__text';

--- a/packages/Form/Input/text/src/TextInput.js
+++ b/packages/Form/Input/text/src/TextInput.js
@@ -44,6 +44,7 @@ const TextInput = props => {
     isVisible,
     className,
     forceDisplayMessage,
+    maxLength,
     ...otherProps
   } = props;
   const inputClassModifier = FormClassManager.getInputClassModifier(
@@ -84,6 +85,7 @@ const TextInput = props => {
           disabled={disabled}
           placeholder={placeholder}
           classModifier={inputClassModifier}
+          maxLength={maxLength}
           {...otherProps}
         />
         {children}

--- a/packages/Form/Input/textarea/src/Textarea.js
+++ b/packages/Form/Input/textarea/src/Textarea.js
@@ -20,6 +20,7 @@ const Textarea = props => {
     onChange,
     rows,
     cols,
+    maxLength,
     ...otherProps
   } = props;
 
@@ -38,6 +39,7 @@ const Textarea = props => {
       disabled={disabled}
       placeholder={placeholder}
       ref={inputRef}
+      maxLength={maxLength}
       {...omitProperties(otherProps)}
     />
   );
@@ -54,9 +56,11 @@ const defaultProps = {
   placeholder: '',
 };
 
-const EnhancedComponent = withInput(defaultClassName, propTypes, defaultProps)(
-  Textarea
-);
+const EnhancedComponent = withInput(
+  defaultClassName,
+  propTypes,
+  defaultProps
+)(Textarea);
 
 EnhancedComponent.Clone = Input.Clone;
 EnhancedComponent.displayName = Textarea.name;

--- a/packages/Form/Input/textarea/src/TextareaInput.js
+++ b/packages/Form/Input/textarea/src/TextareaInput.js
@@ -47,6 +47,7 @@ const TextareaInput = props => {
     value,
     readOnly,
     placeholder,
+    maxLength,
     ...otherProps
   } = props;
   const inputClassModifier = FormClassManager.getInputClassModifier(
@@ -91,6 +92,7 @@ const TextareaInput = props => {
           disabled={disabled}
           placeholder={placeholder}
           classModifier={inputClassModifier}
+          maxLength={maxLength}
           {...otherProps}
         />
         {children}

--- a/storybook/storybook/src/packages/Form/Input/number/src/NumberInput.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/number/src/NumberInput.stories.js
@@ -34,6 +34,7 @@ const NumberInputStory = () => (
       className={text('className', '')}
       tabIndex={text('tabIndex', '')}
       autoFocus={boolean('autoFocus', true)}
+      maxLength={text('maxLength', '')}
       classNameContainerLabel={text(
         'classNameContainerLabel',
         InputConstants.defaultProps.classNameContainerLabel
@@ -68,6 +69,7 @@ const NumberInputStoryRequired = () => (
       className={text('className', '')}
       tabIndex={text('tabIndex', '')}
       autoFocus={boolean('autoFocus', true)}
+      maxLength={text('maxLength', '')}
       classNameContainerLabel={text(
         'classNameContainerLabel',
         InputConstants.defaultProps.classNameContainerLabel
@@ -102,6 +104,7 @@ const NumberStory = () => (
           className={text('className', '')}
           tabIndex={text('tabIndex', '')}
           autoFocus={boolean('autoFocus', true)}
+          maxLength={text('maxLength', '')}
         />
         <HelpMessage
           message={text('helpMessage', 'Enter the place name, ex : Webcenter')}

--- a/storybook/storybook/src/packages/Form/Input/text/src/TextInput.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/text/src/TextInput.stories.js
@@ -34,6 +34,7 @@ const TextInputStory = () => (
       className={text('className', '')}
       tabIndex={text('tabIndex', '')}
       autoFocus={boolean('autoFocus', true)}
+      maxLength={text('maxLength', '')}
       classNameContainerLabel={text(
         'classNameContainerLabel',
         Constants.defaultProps.classNameContainerLabel
@@ -67,6 +68,7 @@ const TextInputStoryRequired = () => (
       className={text('className', '')}
       tabIndex={text('tabIndex', '')}
       autoFocus={boolean('autoFocus', true)}
+      maxLength={text('maxLength', '')}
       classNameContainerLabel={text(
         'classNameContainerLabel',
         Constants.defaultProps.classNameContainerLabel
@@ -100,6 +102,7 @@ const TextInputErrorStory = () => (
       className={text('className', '')}
       tabIndex={text('tabIndex', '')}
       autoFocus={boolean('autoFocus', false)}
+      maxLength={text('maxLength', '')}
       classNameContainerLabel={text(
         'classNameContainerLabel',
         Constants.defaultProps.classNameContainerLabel
@@ -134,6 +137,7 @@ const TextStory = () => (
           className={text('className', '')}
           tabIndex={text('tabIndex', null)}
           autoFocus={boolean('autoFocus', true)}
+          maxLength={text('maxLength', '')}
         />
         <HelpMessage
           message={text('helpMessage', 'Enter the place name, ex : Webcenter')}
@@ -165,6 +169,7 @@ const TextErrorStory = () => (
           className={text('className', '')}
           tabIndex={text('tabIndex', null)}
           autoFocus={boolean('autoFocus', false)}
+          maxLength={text('maxLength', '')}
         />
         <HelpMessage
           message={text('helpMessage', 'Enter the place name, ex : Webcenter')}
@@ -196,6 +201,7 @@ const TextSuccessStory = () => (
           className={text('className', '')}
           tabIndex={text('tabIndex', null)}
           autoFocus={boolean('autoFocus', false)}
+          maxLength={text('maxLength', '')}
         />
         <HelpMessage
           message={text('helpMessage', 'Enter the place name, ex : Webcenter')}
@@ -227,6 +233,7 @@ const TextDisabledStory = () => (
           className={text('className', '')}
           tabIndex={text('tabIndex', null)}
           autoFocus={boolean('autoFocus', false)}
+          maxLength={text('maxLength', '')}
         />
         <HelpMessage
           message={text('helpMessage', 'Enter the place name, ex : Webcenter')}

--- a/storybook/storybook/src/packages/Form/Input/textarea/src/Textarea.stories.js
+++ b/storybook/storybook/src/packages/Form/Input/textarea/src/Textarea.stories.js
@@ -38,6 +38,7 @@ const TextareaInputStory = () => (
       className={text('className', '')}
       tabIndex={text('tabIndex', null)}
       autoFocus={boolean('autoFocus', true)}
+      maxLength={text('maxLength', '')}
       classNameContainerLabel={text(
         'classNameContainerLabel',
         InputConstants.defaultProps.classNameContainerLabel


### PR DESCRIPTION
### Description of the issue

Current form inputs does not accepts maxLength props which is usefull when you want to easily controle the length of user's inputs on you formulary fields. It also avoid developer to code complex form checks to ensure users did not wrote too big string/numbers on form fields.

### Person(s) for reviewing proposed changes

@johnmeunier @JLou @arnaudforaison @guillaumechervet @croquet-mickael @samuel-gomez 

