### PR TITLE
fix(sass): fixing issue #922

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,7 @@
       "dependencies": {
         "autoprefixer": "^10.0.1",
         "clean-css": "^4.2.3",
-        "find": "^0.3.0",
-        "sass": "^1.29.0"
+        "find": "^0.3.0"
       },
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "^7.12.1",
@@ -80,6 +79,7 @@
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
         "rimraf": "^3.0.2",
+        "sass": "^1.43.4",
         "sass-loader": "^10.0.5",
         "storybook-readme": "^5.0.9",
         "ts-jest": "^26.4.3",
@@ -9732,6 +9732,7 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -10687,6 +10688,7 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10845,6 +10847,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -11415,6 +11418,7 @@
     },
     "node_modules/chokidar": {
       "version": "3.5.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -15580,6 +15584,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -17186,6 +17191,7 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -18585,6 +18591,7 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -18752,6 +18759,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -18791,6 +18799,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -18829,6 +18838,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -23529,6 +23539,7 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -24544,6 +24555,7 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -26293,6 +26305,7 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -27408,6 +27421,7 @@
     },
     "node_modules/sass": {
       "version": "1.43.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -29887,6 +29901,7 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -39770,6 +39785,7 @@
     },
     "anymatch": {
       "version": "3.1.2",
+      "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -40402,7 +40418,8 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.2.0"
+      "version": "2.2.0",
+      "dev": true
     },
     "bluebird": {
       "version": "3.7.2",
@@ -40510,6 +40527,7 @@
     },
     "braces": {
       "version": "3.0.2",
+      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -40903,6 +40921,7 @@
     },
     "chokidar": {
       "version": "3.5.2",
+      "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -43773,6 +43792,7 @@
     },
     "fill-range": {
       "version": "7.0.1",
+      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -44876,6 +44896,7 @@
     },
     "glob-parent": {
       "version": "5.1.2",
+      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -45798,6 +45819,7 @@
     },
     "is-binary-path": {
       "version": "2.1.0",
+      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -45881,7 +45903,8 @@
       }
     },
     "is-extglob": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "is-finite": {
       "version": "1.1.0",
@@ -45901,6 +45924,7 @@
     },
     "is-glob": {
       "version": "4.0.3",
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -45918,7 +45942,8 @@
       "dev": true
     },
     "is-number": {
-      "version": "7.0.0"
+      "version": "7.0.0",
+      "dev": true
     },
     "is-number-object": {
       "version": "1.0.6",
@@ -49118,7 +49143,8 @@
       }
     },
     "normalize-path": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "normalize-range": {
       "version": "0.1.2"
@@ -49797,7 +49823,8 @@
       "version": "1.0.0"
     },
     "picomatch": {
-      "version": "2.3.0"
+      "version": "2.3.0",
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",
@@ -50947,6 +50974,7 @@
     },
     "readdirp": {
       "version": "3.6.0",
+      "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -51698,6 +51726,7 @@
     },
     "sass": {
       "version": "1.43.4",
+      "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
       }
@@ -53388,6 +53417,7 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
+      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "react-dom": "^16.14.0",
     "react-test-renderer": "^16.14.0",
     "rimraf": "^3.0.2",
+    "sass": "^1.43.4",
     "sass-loader": "^10.0.5",
     "storybook-readme": "^5.0.9",
     "ts-jest": "^26.4.3",
@@ -99,8 +100,7 @@
   "dependencies": {
     "autoprefixer": "^10.0.1",
     "clean-css": "^4.2.3",
-    "find": "^0.3.0",
-    "sass": "^1.29.0"
+    "find": "^0.3.0"
   },
   "engines": {
     "npm": ">=7.0.0"

--- a/packages/Form/Input/card/src/card.scss
+++ b/packages/Form/Input/card/src/card.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 @import '@axa-fr/react-toolkit-core/src/common/scss/core.scss';
 
 .af-rccard-group {
@@ -229,7 +231,7 @@ $nb-card-max: 5;
 
 @for $i from 1 through $nb-card-max {
   .af-rccard__#{$i} .af-rccard {
-    flex: 0 0 percentage(1 / $i);
-    width: percentage(1 / $i);
+    flex: 0 0 percentage(math.div(1, $i));
+    width: percentage(math.div(1, $i));
   }
 }

--- a/packages/core/src/common/scss/_custom-af.scss
+++ b/packages/core/src/common/scss/_custom-af.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 @import './_custom-af-colorsvariables';
 
 $gray-lighter: #eceeef !default;
@@ -56,7 +58,7 @@ $universes: (
 }
 
 @function rem($size) {
-  $remSize: $size / 16px;
+  $remSize: math.div($size, 16px);
   @return #{$remSize}rem;
 }
 

--- a/packages/core/src/common/scss/_functions.scss
+++ b/packages/core/src/common/scss/_functions.scss
@@ -59,7 +59,7 @@
   $g: green($color);
   $b: blue($color);
 
-  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) * 0.001;
 
   @if ($yiq >= $yiq-contrasted-threshold) {
     @return $yiq-text-dark;

--- a/packages/core/src/common/scss/_variables.scss
+++ b/packages/core/src/common/scss/_variables.scss
@@ -275,7 +275,7 @@ $h4-font-size: $font-size-base * 1.5 !default;
 $h5-font-size: $font-size-base * 1.25 !default;
 $h6-font-size: $font-size-base !default;
 
-$headings-margin-bottom: ($spacer / 2) !default;
+$headings-margin-bottom: ($spacer * 0.5) !default;
 $headings-font-family: inherit !default;
 $headings-font-weight: 500 !default;
 $headings-line-height: 1.2 !default;
@@ -669,11 +669,11 @@ $nav-pills-link-active-color: $component-active-color !default;
 $nav-pills-link-active-bg: $component-active-bg !default;
 
 $nav-divider-color: $gray-200 !default;
-$nav-divider-margin-y: ($spacer / 2) !default;
+$nav-divider-margin-y: ($spacer * 0.5) !default;
 
 // Navbar
 
-$navbar-padding-y: ($spacer / 2) !default;
+$navbar-padding-y: ($spacer * 0.5) !default;
 $navbar-padding-x: $spacer !default;
 
 $navbar-nav-link-padding-x: 0.5rem !default;
@@ -684,7 +684,7 @@ $nav-link-height: (
   $font-size-base * $line-height-base + $nav-link-padding-y * 2
 ) !default;
 $navbar-brand-height: $navbar-brand-font-size * $line-height-base !default;
-$navbar-brand-padding-y: ($nav-link-height - $navbar-brand-height) / 2 !default;
+$navbar-brand-padding-y: ($nav-link-height - $navbar-brand-height) * 0.5 !default;
 
 $navbar-toggler-padding-y: 0.25rem !default;
 $navbar-toggler-padding-x: 0.75rem !default;
@@ -763,7 +763,7 @@ $card-bg: $white !default;
 
 $card-img-overlay-padding: 1.25rem !default;
 
-$card-group-margin: ($grid-gutter-width / 2) !default;
+$card-group-margin: ($grid-gutter-width * 0.5) !default;
 $card-deck-margin: $card-group-margin !default;
 
 $card-columns-count: 3 !default;


### PR DESCRIPTION
### Issue and Steps to Reproduce

Résolution de l'issue 992, l'avertissement n'apparait plus car le / pour la division n'est plus utilisé.

utilisation de la migration Automatique proposée par [sass](https://sass-lang.com/documentation/breaking-changes/slash-div#automatic-migration)

Description of the issue

Division using / are deprecated and going to be removed in dart sass 2.0.0

When you build an app with sass 1.35.1, you get a warning saying : "DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0."

This issue appears mainly with the file @axa-fr\react-toolkit-core\src\common\scss_variables.scss