### PR TITLE
refactor(Restitution): add children property and export RestitutionList

### DIFF
--- a/packages/restitution/README.md
+++ b/packages/restitution/README.md
@@ -18,6 +18,7 @@ import {
   SectionRestitutionRow,
   SectionRestitutionColumn,
   Restitution,
+  RestitutionList,
 } from '@axa-fr/react-toolkit-restitution';
 import '@axa-fr/react-toolkit-restitution/dist/af-restitution.css';
 ```
@@ -47,71 +48,85 @@ const RestititutionDefault = () => (
     <SectionRestitution>
       <SectionRestitutionRow title="Base de calcul des prestations">
         <SectionRestitutionColumn>
-          <Restitution label="TA" value="99,99 %" />
-          <Restitution label="EURO" value="EURO" />
-          <Restitution label="TT" value="" />
-          <Restitution
-            label="Garanties complémentaires"
-            classModifier="marge"
-            values={[
-              'Vol au domicile',
-              'Vol étendu aux appareils nomades',
-              'Bris des glaces',
-              'Plomberie et électricité',
-              'Jardin',
-            ]}
-          />
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">EURO</Restitution>
+          <Restitution label="TT" />
+          <Restitution label="Garanties complémentaires" classModifier="marge">
+            <RestitutionList
+              values={[
+                'Vol au domicile',
+                'Vol étendu aux appareils nomades',
+                'Bris des glaces',
+                'Plomberie et électricité',
+                'Jardin',
+              ]}
+            />
+          </Restitution>
         </SectionRestitutionColumn>
         <SectionRestitutionColumn classModifier="test">
-          <Restitution label="TA" value="99,99 %" />
-          <Restitution label="EURO" value="EURO" />
-          <Restitution label="TT" value="" />
-          <Restitution
-            label="Garanties complémentaires"
-            classModifier="marge"
-            values={[
-              'Vol au domicile',
-              'Vol étendu aux appareils nomades',
-              'Bris des glaces',
-              'Plomberie et électricité',
-              'Jardin',
-            ]}
-          />
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">EURO</Restitution>
+          <Restitution label="TT" />
+          <Restitution label="Garanties complémentaires" classModifier="marge">
+            <RestitutionList
+              values={[
+                'Vol au domicile',
+                'Vol étendu aux appareils nomades',
+                'Bris des glaces',
+                'Plomberie et électricité',
+                'Jardin',
+              ]}
+            />
+          </Restitution>
         </SectionRestitutionColumn>
       </SectionRestitutionRow>
 
       <SectionRestitutionRow title="Base de calcul des prestations">
         <SectionRestitutionColumn>
-          <Restitution label="TA" value="99,99 %" />
-          <Restitution label="EURO" value="EURO" />
-          <Restitution
-            label="Garanties complémentaires"
-            values={[
-              'Vol au domicile',
-              'Vol étendu aux appareils nomades',
-              'Bris des glaces',
-              'Plomberie et électricité',
-              'Jardin',
-            ]}
-          />
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">EURO</Restitution>
+          <Restitution label="TT" />
+          <Restitution label="Garanties complémentaires" classModifier="marge">
+            <RestitutionList
+              values={[
+                'Vol au domicile',
+                'Vol étendu aux appareils nomades',
+                'Bris des glaces',
+                'Plomberie et électricité',
+                'Jardin',
+              ]}
+            />
+          </Restitution>
         </SectionRestitutionColumn>
         <SectionRestitutionColumn>
-          <Restitution label="TA" value="99,99 %" />
-          <Restitution
-            label="EURO"
-            value={<span style={{ textDecoration: 'underline' }}>EURO</span>}
-          />
-          <Restitution
-            label="Garanties complémentaires"
-            classModifier="marge"
-            values={[
-              'Vol au domicile',
-              'Vol étendu aux appareils nomades',
-              'Bris des glaces',
-              'Plomberie et électricité',
-              'Jardin',
-            ]}
-          />
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">
+            <span style={{ textDecoration: 'underline' }}>EURO</span>
+          </Restitution>
+          <Restitution label="Garanties complémentaires" classModifier="marge">
+            <RestitutionList
+              values={[
+                'Vol au domicile',
+                'Vol étendu aux appareils nomades',
+                'Bris des glaces',
+                'Plomberie et électricité',
+                'Jardin',
+              ]}
+            />
+          </Restitution>
+        </SectionRestitutionColumn>
+      </SectionRestitutionRow>
+
+      <SectionRestitutionRow>
+        <SectionRestitutionColumn title="Base de calcul des prestations">
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">EURO</Restitution>
+        </SectionRestitutionColumn>
+        <SectionRestitutionColumn title="Base de calcul des prestations">
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">
+            <span style={{ textDecoration: 'underline' }}>EURO</span>
+          </Restitution>
         </SectionRestitutionColumn>
       </SectionRestitutionRow>
     </SectionRestitution>

--- a/packages/restitution/src/Restitution.stories.tsx
+++ b/packages/restitution/src/Restitution.stories.tsx
@@ -7,6 +7,7 @@ import SectionRestitution from './SectionRestitution';
 import SectionRestitutionColumn from './SectionRestitutionColumn';
 import SectionRestitutionRow from './SectionRestitutionRow';
 import Readme from '../README.md';
+import RestitutionList from './RestitutionList';
 
 const withPreventDefaultClick = (next: any) => (e: any) => {
   e.preventDefault();
@@ -44,71 +45,85 @@ export const Default = () => (
     <SectionRestitution>
       <SectionRestitutionRow title="Base de calcul des prestations">
         <SectionRestitutionColumn>
-          <Restitution label="TA" value="99,99 %" />
-          <Restitution label="EURO" value="EURO" />
-          <Restitution label="TT" value={null} />
-          <Restitution
-            label="Garanties complémentaires"
-            classModifier="marge"
-            values={[
-              'Vol au domicile',
-              'Vol étendu aux appareils nomades',
-              'Bris des glaces',
-              'Plomberie et électricité',
-              'Jardin',
-            ]}
-          />
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">EURO</Restitution>
+          <Restitution label="TT" />
+          <Restitution label="Garanties complémentaires" classModifier="marge">
+            <RestitutionList
+              values={[
+                'Vol au domicile',
+                'Vol étendu aux appareils nomades',
+                'Bris des glaces',
+                'Plomberie et électricité',
+                'Jardin',
+              ]}
+            />
+          </Restitution>
         </SectionRestitutionColumn>
         <SectionRestitutionColumn classModifier="test">
-          <Restitution label="TA" value="99,99 %" />
-          <Restitution label="EURO" value="EURO" />
-          <Restitution label="TT" value={undefined} />
-          <Restitution
-            label="Garanties complémentaires"
-            classModifier="marge"
-            values={[
-              'Vol au domicile',
-              'Vol étendu aux appareils nomades',
-              'Bris des glaces',
-              'Plomberie et électricité',
-              'Jardin',
-            ]}
-          />
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">EURO</Restitution>
+          <Restitution label="TT" />
+          <Restitution label="Garanties complémentaires" classModifier="marge">
+            <RestitutionList
+              values={[
+                'Vol au domicile',
+                'Vol étendu aux appareils nomades',
+                'Bris des glaces',
+                'Plomberie et électricité',
+                'Jardin',
+              ]}
+            />
+          </Restitution>
         </SectionRestitutionColumn>
       </SectionRestitutionRow>
 
       <SectionRestitutionRow title="Base de calcul des prestations">
         <SectionRestitutionColumn>
-          <Restitution label="TA" value="99,99 %" />
-          <Restitution label="EURO" value="EURO" />
-          <Restitution
-            label="Garanties complémentaires"
-            values={[
-              'Vol au domicile',
-              'Vol étendu aux appareils nomades',
-              'Bris des glaces',
-              'Plomberie et électricité',
-              'Jardin',
-            ]}
-          />
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">EURO</Restitution>
+          <Restitution label="TT" />
+          <Restitution label="Garanties complémentaires" classModifier="marge">
+            <RestitutionList
+              values={[
+                'Vol au domicile',
+                'Vol étendu aux appareils nomades',
+                'Bris des glaces',
+                'Plomberie et électricité',
+                'Jardin',
+              ]}
+            />
+          </Restitution>
         </SectionRestitutionColumn>
         <SectionRestitutionColumn>
-          <Restitution label="TA" value="99,99 %" />
-          <Restitution
-            label="EURO"
-            value={<span style={{ textDecoration: 'underline' }}>EURO</span>}
-          />
-          <Restitution
-            label="Garanties complémentaires"
-            classModifier="marge"
-            values={[
-              'Vol au domicile',
-              'Vol étendu aux appareils nomades',
-              'Bris des glaces',
-              'Plomberie et électricité',
-              'Jardin',
-            ]}
-          />
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">
+            <span style={{ textDecoration: 'underline' }}>EURO</span>
+          </Restitution>
+          <Restitution label="Garanties complémentaires" classModifier="marge">
+            <RestitutionList
+              values={[
+                'Vol au domicile',
+                'Vol étendu aux appareils nomades',
+                'Bris des glaces',
+                'Plomberie et électricité',
+                'Jardin',
+              ]}
+            />
+          </Restitution>
+        </SectionRestitutionColumn>
+      </SectionRestitutionRow>
+
+      <SectionRestitutionRow>
+        <SectionRestitutionColumn title="Base de calcul des prestations">
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">EURO</Restitution>
+        </SectionRestitutionColumn>
+        <SectionRestitutionColumn title="Base de calcul des prestations">
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">
+            <span style={{ textDecoration: 'underline' }}>EURO</span>
+          </Restitution>
         </SectionRestitutionColumn>
       </SectionRestitutionRow>
     </SectionRestitution>

--- a/packages/restitution/src/Restitution.tsx
+++ b/packages/restitution/src/Restitution.tsx
@@ -9,34 +9,20 @@ import {
 
 const DEFAULT_CLASSNAME = 'af-restitution__listdef';
 
-const RestitutionValues = ({ values }: Pick<RestitutionProps, 'values'>) => {
-  const li = values.map((v) => (
-    <li key={v} className="af-restitution__listul-item">
-      {v}
-    </li>
-  ));
-
-  return <ul className="af-restitution__listul">{li}</ul>;
-};
-
 type RestitutionProps = ComponentPropsWithoutRef<'dl'> & {
   label: string;
-  value?: ReactNode;
-  values?: string[];
+  children?: ReactNode;
 };
 const Restitution = ({
   label,
-  value = '-',
-  values,
+  children = '-',
   className,
 }: RestitutionProps) => (
   <dl className={className}>
     <dt className="af-restitution__listdef-item">
       <span className="af-restitution__text">{label}</span>
     </dt>
-    <dd className="af-restitution__listdef-value">
-      {values ? <RestitutionValues values={values} /> : value}
-    </dd>
+    <dd className="af-restitution__listdef-value">{children}</dd>
   </dl>
 );
 

--- a/packages/restitution/src/RestitutionList.tsx
+++ b/packages/restitution/src/RestitutionList.tsx
@@ -1,0 +1,21 @@
+import React, { ComponentPropsWithoutRef } from 'react';
+
+type RestitutionListProps = ComponentPropsWithoutRef<'ul'> & {
+  values: string[];
+};
+
+const RestitutionList = ({ values, ...props }: RestitutionListProps) => {
+  const li = values.map((value: string) => (
+    <li key={value} className="af-restitution__listul-item">
+      {value}
+    </li>
+  ));
+
+  return (
+    <ul className="af-restitution__listul" {...props}>
+      {li}
+    </ul>
+  );
+};
+
+export default RestitutionList;

--- a/packages/restitution/src/__tests__/Restitution.spec.tsx
+++ b/packages/restitution/src/__tests__/Restitution.spec.tsx
@@ -7,6 +7,7 @@ import {
   SectionRestitutionColumn,
   SectionRestitutionRow,
   Restitution,
+  RestitutionList,
 } from '..';
 
 const RightTitle = () => {
@@ -28,71 +29,85 @@ const Component = (
     <SectionRestitution>
       <SectionRestitutionRow title="Base de calcul des prestations">
         <SectionRestitutionColumn>
-          <Restitution label="TA" value="99,99 %" />
-          <Restitution label="EURO" value="EURO" />
-          <Restitution label="TT" value={null} />
-          <Restitution
-            label="Garanties complémentaires"
-            classModifier="marge"
-            values={[
-              'Vol au domicile',
-              'Vol étendu aux appareils nomades',
-              'Bris des glaces',
-              'Plomberie et électricité',
-              'Jardin',
-            ]}
-          />
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">EURO</Restitution>
+          <Restitution label="TT" />
+          <Restitution label="Garanties complémentaires" classModifier="marge">
+            <RestitutionList
+              values={[
+                'Vol au domicile',
+                'Vol étendu aux appareils nomades',
+                'Bris des glaces',
+                'Plomberie et électricité',
+                'Jardin',
+              ]}
+            />
+          </Restitution>
         </SectionRestitutionColumn>
-        <SectionRestitutionColumn>
-          <Restitution label="TA" value="99,99 %" />
-          <Restitution label="EURO" value="EURO" />
-          <Restitution label="TT" value="" />
-          <Restitution
-            label="Garanties complémentaires"
-            classModifier="marge"
-            values={[
-              'Vol au domicile',
-              'Vol étendu aux appareils nomades',
-              'Bris des glaces',
-              'Plomberie et électricité',
-              'Jardin',
-            ]}
-          />
+        <SectionRestitutionColumn classModifier="test">
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">EURO</Restitution>
+          <Restitution label="TT" />
+          <Restitution label="Garanties complémentaires" classModifier="marge">
+            <RestitutionList
+              values={[
+                'Vol au domicile',
+                'Vol étendu aux appareils nomades',
+                'Bris des glaces',
+                'Plomberie et électricité',
+                'Jardin',
+              ]}
+            />
+          </Restitution>
         </SectionRestitutionColumn>
       </SectionRestitutionRow>
 
       <SectionRestitutionRow title="Base de calcul des prestations">
         <SectionRestitutionColumn>
-          <Restitution label="TA" value="99,99 %" />
-          <Restitution label="EURO" value="EURO" />
-          <Restitution
-            label="Garanties complémentaires"
-            values={[
-              'Vol au domicile',
-              'Vol étendu aux appareils nomades',
-              'Bris des glaces',
-              'Plomberie et électricité',
-              'Jardin',
-            ]}
-          />
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">EURO</Restitution>
+          <Restitution label="TT" />
+          <Restitution label="Garanties complémentaires" classModifier="marge">
+            <RestitutionList
+              values={[
+                'Vol au domicile',
+                'Vol étendu aux appareils nomades',
+                'Bris des glaces',
+                'Plomberie et électricité',
+                'Jardin',
+              ]}
+            />
+          </Restitution>
         </SectionRestitutionColumn>
         <SectionRestitutionColumn>
-          <Restitution label="TA" value="99,99 %" />
-          <Restitution
-            label="EURO"
-            value={<span style={{ textDecoration: 'underline' }}>EURO</span>}
-          />
-          <Restitution
-            label="Garanties complémentaires"
-            classModifier="marge"
-            values={[
-              'Vol au domicile',
-              'Vol étendu aux appareils nomades',
-              'Bris des glaces',
-              'Plomberie et électricité',
-              'Jardin',
-            ]}
-          />
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">
+            <span style={{ textDecoration: 'underline' }}>EURO</span>
+          </Restitution>
+          <Restitution label="Garanties complémentaires" classModifier="marge">
+            <RestitutionList
+              values={[
+                'Vol au domicile',
+                'Vol étendu aux appareils nomades',
+                'Bris des glaces',
+                'Plomberie et électricité',
+                'Jardin',
+              ]}
+            />
+          </Restitution>
+        </SectionRestitutionColumn>
+      </SectionRestitutionRow>
+
+      <SectionRestitutionRow>
+        <SectionRestitutionColumn title="Base de calcul des prestations">
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">EURO</Restitution>
+        </SectionRestitutionColumn>
+        <SectionRestitutionColumn title="Base de calcul des prestations">
+          <Restitution label="TA">99,99 %</Restitution>
+          <Restitution label="EURO">
+            <span style={{ textDecoration: 'underline' }}>EURO</span>
+          </Restitution>
         </SectionRestitutionColumn>
       </SectionRestitutionRow>
     </SectionRestitution>

--- a/packages/restitution/src/__tests__/__snapshots__/Restitution.spec.tsx.snap
+++ b/packages/restitution/src/__tests__/__snapshots__/Restitution.spec.tsx.snap
@@ -115,7 +115,9 @@ exports[`<ArticleRestitution /> should render component 1`] = `
               </dt>
               <dd
                 class="af-restitution__listdef-value"
-              />
+              >
+                -
+              </dd>
             </dl>
             <dl
               class="af-restitution__listdef af-restitution__listdef--marge"
@@ -165,7 +167,7 @@ exports[`<ArticleRestitution /> should render component 1`] = `
             </dl>
           </div>
           <div
-            class="col-sm-12 col-md-12 col-lg-6 col-xl-6"
+            class="col-sm-12 col-md-12 col-lg-6 col-xl-6 col-xl-6--test"
           >
             <dl
               class="af-restitution__listdef"
@@ -217,7 +219,9 @@ exports[`<ArticleRestitution /> should render component 1`] = `
               </dt>
               <dd
                 class="af-restitution__listdef-value"
-              />
+              >
+                -
+              </dd>
             </dl>
             <dl
               class="af-restitution__listdef af-restitution__listdef--marge"
@@ -320,6 +324,24 @@ exports[`<ArticleRestitution /> should render component 1`] = `
             </dl>
             <dl
               class="af-restitution__listdef"
+            >
+              <dt
+                class="af-restitution__listdef-item"
+              >
+                <span
+                  class="af-restitution__text"
+                >
+                  TT
+                </span>
+              </dt>
+              <dd
+                class="af-restitution__listdef-value"
+              >
+                -
+              </dd>
+            </dl>
+            <dl
+              class="af-restitution__listdef af-restitution__listdef--marge"
             >
               <dt
                 class="af-restitution__listdef-item"
@@ -452,6 +474,108 @@ exports[`<ArticleRestitution /> should render component 1`] = `
                     Jardin
                   </li>
                 </ul>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+      <div
+        class="col col-sm-12 col-md-12 col-lg-12 col-xl-12"
+      >
+        <div
+          class="row af-restitution__content-left"
+        >
+          <div
+            class="col-sm-12 col-md-12 col-lg-6 col-xl-6"
+          >
+            <div
+              class="af-restitution__content-title"
+            >
+              Base de calcul des prestations
+            </div>
+            <dl
+              class="af-restitution__listdef"
+            >
+              <dt
+                class="af-restitution__listdef-item"
+              >
+                <span
+                  class="af-restitution__text"
+                >
+                  TA
+                </span>
+              </dt>
+              <dd
+                class="af-restitution__listdef-value"
+              >
+                99,99 %
+              </dd>
+            </dl>
+            <dl
+              class="af-restitution__listdef"
+            >
+              <dt
+                class="af-restitution__listdef-item"
+              >
+                <span
+                  class="af-restitution__text"
+                >
+                  EURO
+                </span>
+              </dt>
+              <dd
+                class="af-restitution__listdef-value"
+              >
+                EURO
+              </dd>
+            </dl>
+          </div>
+          <div
+            class="col-sm-12 col-md-12 col-lg-6 col-xl-6"
+          >
+            <div
+              class="af-restitution__content-title"
+            >
+              Base de calcul des prestations
+            </div>
+            <dl
+              class="af-restitution__listdef"
+            >
+              <dt
+                class="af-restitution__listdef-item"
+              >
+                <span
+                  class="af-restitution__text"
+                >
+                  TA
+                </span>
+              </dt>
+              <dd
+                class="af-restitution__listdef-value"
+              >
+                99,99 %
+              </dd>
+            </dl>
+            <dl
+              class="af-restitution__listdef"
+            >
+              <dt
+                class="af-restitution__listdef-item"
+              >
+                <span
+                  class="af-restitution__text"
+                >
+                  EURO
+                </span>
+              </dt>
+              <dd
+                class="af-restitution__listdef-value"
+              >
+                <span
+                  style="text-decoration: underline;"
+                >
+                  EURO
+                </span>
               </dd>
             </dl>
           </div>

--- a/packages/restitution/src/index.ts
+++ b/packages/restitution/src/index.ts
@@ -5,3 +5,4 @@ export { default as SectionRestitutionTitle } from './SectionRestitutionTitle';
 export { default as SectionRestitutionRow } from './SectionRestitutionRow';
 export { default as SectionRestitutionColumn } from './SectionRestitutionColumn';
 export { default as Restitution } from './Restitution';
+export { default as RestitutionList } from './RestitutionList';


### PR DESCRIPTION
### Reference to the issue
Close #949 

### Description of the issue

Following allowing ReactNode in value of Restitution (https://github.com/AxaGuilDEv/react-toolkit/issues/945) properties value and values overlap.
The goal is now to keep only one of the two property.

For example, we can keep value and delete values but export the RestitutionValues component that is used when values is passed in order to let the consumer use that component as children of Restitution.

### Person(s) for reviewing proposed changes

@samuel-gomez 
