### PR TITLE
feat(Summary): allow ReactNode in messages array

### DIFF
--- a/packages/Form/summary/README.md
+++ b/packages/Form/summary/README.md
@@ -19,7 +19,10 @@ import '@axa-fr/react-toolkit-alert/dist/af-alert.css';
 ```javascript
 const SummaryForm = () => (
   <Summary
-    messages={['Field Author is required', 'Field PlaceName is required']}
+    messages={[
+      <span>Field Author is required</span>,
+      'Field PlaceName is required',
+    ]}
     title="Formulaire invalide"
     classModifier="error"
     className="af-alert"

--- a/packages/Form/summary/src/Summary.stories.tsx
+++ b/packages/Form/summary/src/Summary.stories.tsx
@@ -23,7 +23,10 @@ export default {
   },
 } as Meta;
 
-const messages = ['Field Author is required', 'Field PlaceName is required'];
+const messages = [
+  <span>Field Author is required</span>,
+  'Field PlaceName is required',
+];
 
 type SummaryProps = ComponentProps<typeof Summary>;
 const Template: Story<SummaryProps> = (args) => <Summary {...args} />;

--- a/packages/Form/summary/src/Summary.tsx
+++ b/packages/Form/summary/src/Summary.tsx
@@ -1,9 +1,10 @@
-import React, { ComponentPropsWithoutRef } from 'react';
+import React, { ComponentPropsWithoutRef, ReactNode } from 'react';
 import Alert from '@axa-fr/react-toolkit-alert';
+import { createId } from '@axa-fr/react-toolkit-core';
 
 type SummaryProps = Omit<ComponentPropsWithoutRef<typeof Alert>, 'title'> & {
   title?: string;
-  messages?: string[];
+  messages?: ReactNode[];
   isVisible?: boolean;
 };
 const Summary = ({
@@ -23,6 +24,7 @@ const Summary = ({
   if (!messagesNotBlank.length) {
     return null;
   }
+
   return (
     <Alert
       classModifier={classModifier}
@@ -30,11 +32,14 @@ const Summary = ({
       icon="warning-sign"
       title={title}>
       <ul className="af-summary__message-list">
-        {messages.map((message) => (
-          <li className="af-summary__message-item" key={message}>
-            <span>{message}</span>
-          </li>
-        ))}
+        {messages.map((message) => {
+          const id = createId();
+          return (
+            <li className="af-summary__message-item" key={`message_${id}`}>
+              {message}
+            </li>
+          );
+        })}
       </ul>
     </Alert>
   );

--- a/packages/Form/summary/src/__tests__/Summary.spec.tsx
+++ b/packages/Form/summary/src/__tests__/Summary.spec.tsx
@@ -18,4 +18,15 @@ describe('<Summary>', () => {
     const { asFragment } = render(<Summary messages={messages} isVisible />);
     expect(asFragment()).toMatchSnapshot();
   });
+
+  it('Renders correctly with ReactNode in messages', () => {
+    const messages = [
+      <span>Sample message 1</span>,
+      '',
+      'Sample message 2',
+      null,
+    ];
+    const { asFragment } = render(<Summary messages={messages} isVisible />);
+    expect(asFragment()).toMatchSnapshot();
+  });
 });

--- a/packages/Form/summary/src/__tests__/__snapshots__/Summary.spec.tsx.snap
+++ b/packages/Form/summary/src/__tests__/__snapshots__/Summary.spec.tsx.snap
@@ -39,27 +39,78 @@ exports[`<Summary> Renders correctly when visible 1`] = `
           <li
             class="af-summary__message-item"
           >
+            Sample message 1
+          </li>
+          <li
+            class="af-summary__message-item"
+          />
+          <li
+            class="af-summary__message-item"
+          >
+            Sample message 2
+          </li>
+          <li
+            class="af-summary__message-item"
+          />
+        </ul>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<Summary> Renders correctly with ReactNode in messages 1`] = `
+<DocumentFragment>
+  <div
+    class="af-alert af-alert--danger"
+    role="alert"
+  >
+    <div
+      class="af-alert__title"
+    >
+      <div
+        class="af-alert__title-icon"
+      >
+        <i
+          class="glyphicon glyphicon-warning-sign"
+        />
+      </div>
+      <div
+        class="af-alert__title-text"
+      >
+        Invalid form
+      </div>
+    </div>
+    <div
+      class="af-alert__content"
+    >
+      <div
+        class="af-alert__content__left"
+      />
+      <div
+        class="af-alert__content__right"
+      >
+        <ul
+          class="af-summary__message-list"
+        >
+          <li
+            class="af-summary__message-item"
+          >
             <span>
               Sample message 1
             </span>
           </li>
           <li
             class="af-summary__message-item"
-          >
-            <span />
-          </li>
+          />
           <li
             class="af-summary__message-item"
           >
-            <span>
-              Sample message 2
-            </span>
+            Sample message 2
           </li>
           <li
             class="af-summary__message-item"
-          >
-            <span />
-          </li>
+          />
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Related issue
`[Issue](https://github.com/AxaGuilDEv/react-toolkit/issues/975)`

### Description of the issue

`The summary form component allows only an array of string for the messages to be displayed.
We would like to extend that with ReactNode in order to pass more complex messages (with links for example).`

### Person(s) for reviewing proposed changes

@arnaudforaison
