### PR TITLE
fix(Restitution): fixed HeaderRestitution's type missing classModifier

### DIFF
--- a/packages/restitution/src/HeaderRestitution.tsx
+++ b/packages/restitution/src/HeaderRestitution.tsx
@@ -41,7 +41,7 @@ type HeaderRestitutionProps = WithClassModifierOptions &
   HeaderRestitutionBaseProps;
 
 const enhance = compose(
-  identity<HeaderRestitutionBaseProps>(),
+  identity<HeaderRestitutionProps>(),
   withClassDefault(DEFAULT_CLASSNAME),
   withClassModifier()
 );

--- a/packages/restitution/src/__tests__/Restitution.spec.tsx
+++ b/packages/restitution/src/__tests__/Restitution.spec.tsx
@@ -25,6 +25,7 @@ const Component = (
       title="Tarifs"
       subtitle="Tout adhérent, assuré, base (sans EAC ou sans PAC)"
       rightTitle={<RightTitle />}
+      classModifier="myModifier"
     />
     <SectionRestitution>
       <SectionRestitutionRow title="Base de calcul des prestations">

--- a/packages/restitution/src/__tests__/__snapshots__/Restitution.spec.tsx.snap
+++ b/packages/restitution/src/__tests__/__snapshots__/Restitution.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`<ArticleRestitution /> should render component 1`] = `
     class="af-restitution af-restitution--lg"
   >
     <header
-      class="af-restitution__header"
+      class="af-restitution__header af-restitution__header--myModifier"
     >
       <div
         class="af-restitution__header-left"


### PR DESCRIPTION
## Related issue


### Description of the issue

The outgoing type for HeaderRestitution was the base type and not the enhanced one with classModifier.
![image](https://user-images.githubusercontent.com/183460/195795568-9adf6a2f-eb1b-45fd-9c25-aaa2ca519003.png)

# Important

Before creating a pull request run unit tests

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```

## Current workaround :

```ts
interface HeaderRestitutionProps {
  className?: string;
  title: React.ReactNode;
  subtitle?: React.ReactNode;
  rightTitle?: React.ReactNode;
  classModifier?: string | null;
  defaultClassName?: string | null;
}
const HeaderRestitutionFixed: (props: HeaderRestitutionProps) => JSX.Element = HeaderRestitution as never;
        
const MyComponent = () => (
      <HeaderRestitutionFixed
          classModifier="stackedRight" // no error
      />
);
```
