### PR TITLE
[DateInput] Suppression des props déstructurées et pas utilisées

### DIFF
--- a/packages/Form/Input/date/src/Date.stories.tsx
+++ b/packages/Form/Input/date/src/Date.stories.tsx
@@ -66,10 +66,16 @@ DateInputStory.args = {
   classNameContainerLabel: 'col-md-2',
   classNameContainerInput: 'col-md-10',
 };
+DateInputStory.argTypes = {
+  onChange: { action: 'changed' },
+};
 
 export const DateInputStoryRequired: ComponentStory<typeof DateInput> =
   Template.bind({});
 DateInputStoryRequired.args = {
   ...DateInputStory.args,
   classModifier: 'required',
+};
+DateInputStoryRequired.argTypes = {
+  onChange: { action: 'changed' },
 };

--- a/packages/Form/Input/date/src/DateInput.tsx
+++ b/packages/Form/Input/date/src/DateInput.tsx
@@ -29,10 +29,6 @@ const DateInput = ({
   isVisible,
   forceDisplayMessage,
   className,
-  name,
-  value,
-  onChange,
-  readOnly,
   disabled,
   ...otherProps
 }: Props) => {
@@ -58,9 +54,7 @@ const DateInput = ({
         className="af-form__date"
         classModifier={inputFieldClassModifier}>
         <Date
-          name={name}
           id={inputId}
-          value={value}
           classModifier={inputClassModifier}
           disabled={disabled}
           {...otherProps}


### PR DESCRIPTION
Dans le composant DateInput, des props sont déstructurées mais pas utilisées, ce qui a pour effet de ne pas passer toutes les props nécessaires au composant wrapper Date.

Cette PR fait le nettoyage et la remédiation.