### PR TITLE
Fixed esm build for package all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ yarn-error.log*
 /**/storybook-static/
 /**/axa-static/
 /**/dist/
+/**/esm/
 /**/.toolkit/
 jest-test-results.json
 /packages/**/LICENSE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ npm install
 After installing dependencies, it's necessary to build all package via `lerna` with:
 
 ```sh
-npm build
+npm run build
 ```
 
 At this point you are ready to contribute.

--- a/packages/all/.gitignore
+++ b/packages/all/.gitignore
@@ -1,2 +1,2 @@
 component
-esm
+

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -6,7 +6,8 @@
   "types": "esm/index.d.ts",
   "private": false,
   "scripts": {
-    "build": "rimraf ./component rimraf ./esm && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json"
+    "prebuild": "rimraf ./component & rimraf ./esm",
+    "build": "tsc -p tsconfig.json & tsc -p tsconfig-cjs.json"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",


### PR DESCRIPTION
## Related issue

### Description of the issue

esm build files were not present in the 2.0.0 npm package, meaning we could not get tree-shaking or making the package unsuable in esbuild, vite & friends.

### Person(s) for reviewing proposed changes

@arnaudforaison 