### PR TITLE
feat(helpinfo): add new high level component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -28,6 +28,7 @@ module.exports = {
     '../packages/Form/steps/src/*.stories.@(ts|tsx|js)',
     '../packages/Form/summary/src/*.stories.@(ts|tsx|js)',
     '../packages/help/src/*.stories.@(ts|tsx|js)',
+    '../packages/helpinfo/src/*.stories.@(ts|tsx|js)',
     '../packages/highlight/src/*.stories.@(ts|tsx|js)',
     '../packages/icon/src/*.stories.@(ts|tsx|js)',
     '../packages/Layout/footer/src/*.stories.@(ts|tsx|js)',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -21,6 +21,7 @@ export const parameters = {
   options: {
     storySort: {
       order: [
+        'Components high level',
         'Components',
         'Form elements',
         'Structure',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "packages/Modal/*"
       ],
       "dependencies": {
+        "@popperjs/core": "^2.11.6",
         "autoprefixer": "10.0.1",
         "clean-css": "4.2.3",
         "find": "0.3.0"
@@ -197,6 +198,10 @@
     },
     "node_modules/@axa-fr/react-toolkit-help": {
       "resolved": "packages/help",
+      "link": true
+    },
+    "node_modules/@axa-fr/react-toolkit-helpinfo": {
+      "resolved": "packages/helpinfo",
       "link": true
     },
     "node_modules/@axa-fr/react-toolkit-highlight": {
@@ -7556,9 +7561,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.5",
-      "license": "MIT",
-      "peer": true,
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -35171,6 +35176,7 @@
         "@axa-fr/react-toolkit-form-steps": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-form-summary": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-help": "2.0.1-alpha.0",
+        "@axa-fr/react-toolkit-helpinfo": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-highlight": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-icon": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-layout-footer": "2.0.1-alpha.0",
@@ -35519,6 +35525,18 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "packages/helpinfo": {
+      "version": "2.0.1-alpha.0",
+      "license": "MIT",
+      "dependencies": {
+        "@axa-fr/react-toolkit-core": "2.0.1-alpha.0",
+        "@axa-fr/react-toolkit-popover": "2.0.1-alpha.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "packages/highlight": {
       "name": "@axa-fr/react-toolkit-highlight",
       "version": "2.0.1-alpha.0",
@@ -35785,6 +35803,7 @@
         "@axa-fr/react-toolkit-form-steps": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-form-summary": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-help": "2.0.1-alpha.0",
+        "@axa-fr/react-toolkit-helpinfo": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-highlight": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-icon": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-layout-footer": "2.0.1-alpha.0",
@@ -35976,6 +35995,13 @@
     },
     "@axa-fr/react-toolkit-help": {
       "version": "file:packages/help",
+      "requires": {
+        "@axa-fr/react-toolkit-core": "2.0.1-alpha.0",
+        "@axa-fr/react-toolkit-popover": "2.0.1-alpha.0"
+      }
+    },
+    "@axa-fr/react-toolkit-helpinfo": {
+      "version": "file:packages/helpinfo",
       "requires": {
         "@axa-fr/react-toolkit-core": "2.0.1-alpha.0",
         "@axa-fr/react-toolkit-popover": "2.0.1-alpha.0"
@@ -41084,8 +41110,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.11.5",
-      "peer": true
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
+    "@popperjs/core": "^2.11.6",
     "autoprefixer": "10.0.1",
     "clean-css": "4.2.3",
     "find": "0.3.0"

--- a/packages/Modal/boolean/src/ModalBoolean.stories.tsx
+++ b/packages/Modal/boolean/src/ModalBoolean.stories.tsx
@@ -4,7 +4,7 @@ import BooleanModal from './ModalBoolean';
 import readme from '../README.md';
 
 export default {
-  title: 'Components/Modal/Boolean',
+  title: 'Components high level/Modal/Boolean',
   component: BooleanModal,
   parameters: {
     readme: {

--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -40,6 +40,7 @@
     "@axa-fr/react-toolkit-form-steps": "2.0.1-alpha.0",
     "@axa-fr/react-toolkit-form-summary": "2.0.1-alpha.0",
     "@axa-fr/react-toolkit-help": "2.0.1-alpha.0",
+    "@axa-fr/react-toolkit-helpinfo": "2.0.1-alpha.0",
     "@axa-fr/react-toolkit-highlight": "2.0.1-alpha.0",
     "@axa-fr/react-toolkit-icon": "2.0.1-alpha.0",
     "@axa-fr/react-toolkit-layout-footer": "2.0.1-alpha.0",

--- a/packages/all/src/help-info.ts
+++ b/packages/all/src/help-info.ts
@@ -1,0 +1,1 @@
+export { default as HelpInfo } from '@axa-fr/react-toolkit-helpinfo';

--- a/packages/all/src/index.ts
+++ b/packages/all/src/index.ts
@@ -24,6 +24,7 @@ export * from './form-input-textarea';
 export * from './form-steps';
 export * from './form-summary';
 export * from './help';
+export * from './help-info';
 export * from './highlight';
 export * from './icon';
 export * from './layout-footer';

--- a/packages/help/src/Help.tsx
+++ b/packages/help/src/Help.tsx
@@ -5,6 +5,7 @@ import Popover, {
 } from '@axa-fr/react-toolkit-popover';
 
 export type Props = ComponentPropsWithoutRef<typeof Popover>;
+
 const Help = ({
   className,
   classModifier,

--- a/packages/helpinfo/README.md
+++ b/packages/helpinfo/README.md
@@ -1,0 +1,88 @@
+# `@axa-fr/react-toolkit-helpinfo`
+
+1. [Text Story](#text-story)
+2. [Html Story](#html-story)
+
+## Text Story
+
+### Installation
+
+```shell script
+npm i @axa-fr/react-toolkit-helpinfo
+npm i @axa-fr/react-toolkit-popover
+```
+
+### Import
+
+```javascript
+import HelpInfo from '@axa-fr/react-toolkit-helpinfo';
+import { PopoverPlacements, PopoverModes } from '@axa-fr/react-toolkit-popover';
+import '@axa-fr/react-toolkit-popover/dist/af-popover.css';
+import '@axa-fr/react-toolkit-popover/dist/af-help-info.css';
+```
+
+### Use
+
+```javascript
+const TextStory = () => (
+  <form className="af-form" name="myform">
+    <HelpInfo
+      mode={PopoverModes.click}
+      placement={PopoverPlacements.right}
+      content="Lorem ipsum dolor sit amet">
+      My content
+    </HelpInfo>
+  </form>
+);
+export default TextStory;
+```
+
+## Html Story
+
+### Installation
+
+```shell script
+npm i @axa-fr/react-toolkit-helpinfo
+npm i @axa-fr/react-toolkit-popover
+```
+
+### Import
+
+```javascript
+import HelpInfo from '@axa-fr/react-toolkit-help-info';
+import { PopoverPlacements, PopoverModes } from '@axa-fr/react-toolkit-popover';
+import '@axa-fr/react-toolkit-popover/dist/af-popover.css';
+import '@axa-fr/react-toolkit-popover/dist/af-help-info.css';
+```
+
+### Use
+
+```javascript
+const overContent = <div className="af-help-demo__container">
+      <h3 className="af-help-demo__title">Profile</h3>
+      <div className="af-help-demo__infos">
+        <p className="af-help-demo__info">
+          <span className="af-help-demo__info-title">Tweets</span>
+          <span className="af-help-demo__info-number">1,337</span>
+        </p>
+        <p className="af-help-demo__info">
+          <span className="af-help-demo__info-title">Following</span>
+          <span className="af-help-demo__info-number">561</span>
+        </p>
+        <p className="af-help-demo__info">
+          <span className="af-help-demo__info-title">Followers</span>
+          <span className="af-help-demo__info-number">718</span>
+        </p>
+      </div>
+    </div>;
+
+const HtmlStory = () => (
+  <HelpInfo
+    classModifier="custom"
+    mode={PopoverModes.over}
+    placement={PopoverPlacements.right} content={overContent}>
+    <h1>My HTML Content</p>
+  </HelpInfo>
+);
+export default HtmlStory;
+```

--- a/packages/helpinfo/package.json
+++ b/packages/helpinfo/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@axa-fr/react-toolkit-helpinfo",
+  "version": "2.0.1-alpha.0",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "types": "dist/esm/index.d.ts",
+  "private": false,
+  "scripts": {
+    "build": "rimraf ./dist && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+  },
+  "dependencies": {
+    "@axa-fr/react-toolkit-core": "2.0.1-alpha.0",
+    "@axa-fr/react-toolkit-popover": "2.0.1-alpha.0"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AxaGuilDEv/react-toolkit.git"
+  }
+}

--- a/packages/helpinfo/src/HelpInfo.stories.tsx
+++ b/packages/helpinfo/src/HelpInfo.stories.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react';
 import { PopoverPlacements, PopoverModes } from '@axa-fr/react-toolkit-popover';
-import Help from './Help';
+import Button from '@axa-fr/react-toolkit-button';
+import Badge from '@axa-fr/react-toolkit-badge';
+import HelpInfo from './HelpInfo';
 import readme from '../README.md';
-import './help-custom.scss';
+import './help-info.scss';
 
 export default {
-  title: 'Components high level/Help',
-  component: Help,
+  title: 'Components high level/HelpInfo',
+  component: HelpInfo,
   parameters: {
     readme: {
       sidebar: readme,
@@ -35,16 +37,18 @@ export default {
   },
 } as Meta;
 
-type HelpProps = React.ComponentProps<typeof Help>;
+type HelpProps = React.ComponentProps<typeof HelpInfo>;
 const Template: Story<HelpProps> = ({ children, ...args }) => (
-  <Help {...args}>{children}</Help>
+  <HelpInfo {...args}>{children}</HelpInfo>
 );
 
 export const TextStory: Story<HelpProps> = Template.bind({});
 TextStory.args = {
-  children: 'Lorem ipsum dolor sit amet',
+  content: 'Lorem ipsum dolor sit amet',
   mode: PopoverModes.click,
   placement: PopoverPlacements.right,
+  children: 'test',
+  isDisabled: false,
 };
 
 const htmlChild = (
@@ -69,8 +73,28 @@ const htmlChild = (
 
 export const HtmlStory: Story<HelpProps> = Template.bind({});
 HtmlStory.args = {
-  children: htmlChild,
+  content: htmlChild,
   classModifier: 'custom',
   mode: PopoverModes.over,
   placement: PopoverPlacements.right,
+  children: 'test with custom hover',
+  isDisabled: false,
+};
+
+export const ButtonStory: Story<HelpProps> = Template.bind({});
+ButtonStory.args = {
+  content: 'Bouton de validation',
+  mode: PopoverModes.over,
+  placement: PopoverPlacements.top,
+  children: <Button>Valider</Button>,
+  isDisabled: false,
+};
+
+export const BadgeStory: Story<HelpProps> = Template.bind({});
+BadgeStory.args = {
+  content: 'Nombre de notifications',
+  mode: PopoverModes.over,
+  placement: PopoverPlacements.top,
+  children: <Badge classModifier="error">5</Badge>,
+  isDisabled: false,
 };

--- a/packages/helpinfo/src/HelpInfo.tsx
+++ b/packages/helpinfo/src/HelpInfo.tsx
@@ -1,0 +1,34 @@
+import React, { ComponentPropsWithoutRef, ReactNode } from 'react';
+import Popover, { PopoverPlacements } from '@axa-fr/react-toolkit-popover';
+import './help-info.scss';
+
+export type Props = ComponentPropsWithoutRef<typeof Popover>;
+
+export type THelpInfo = Props & {
+  content?: ReactNode;
+  isDisabled?: boolean;
+};
+
+const HelpInfo = ({
+  className,
+  children,
+  content,
+  isDisabled,
+  mode = 'hover',
+  classModifier = 'short',
+  placement = PopoverPlacements.top,
+}: THelpInfo) =>
+  !isDisabled && content ? (
+    <Popover
+      className={className}
+      mode={mode}
+      classModifier={classModifier}
+      placement={placement}>
+      <Popover.Pop>{content}</Popover.Pop>
+      <Popover.Over>{children}</Popover.Over>
+    </Popover>
+  ) : (
+    <>{children}</>
+  );
+
+export default HelpInfo;

--- a/packages/helpinfo/src/__tests__/HelpInfo.spec.tsx
+++ b/packages/helpinfo/src/__tests__/HelpInfo.spec.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import UserEvent from '@testing-library/user-event';
+import HelpInfo from '../HelpInfo';
+
+describe('HelpInfo', () => {
+  describe('Mode hover (default)', () => {
+    it('should show help when hovering i', async () => {
+      // Arrange
+      render(<HelpInfo content="Help content">My text</HelpInfo>);
+
+      // Act
+      UserEvent.hover(screen.getByText('My text'));
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.queryByText(/Help content/)).toBeInTheDocument();
+      });
+    });
+
+    it('should hide help when unhovering i', async () => {
+      // Arrange
+      render(<HelpInfo content="Help content">My text</HelpInfo>);
+
+      // Act
+      UserEvent.unhover(screen.getByText('My text'));
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.queryByText(/Help content/)).not.toBeInTheDocument();
+      });
+    });
+
+    it('should not show help before hover', async () => {
+      // Arrange
+      render(<HelpInfo content="Help content">My text</HelpInfo>);
+
+      // Act
+      // No user interaction
+
+      // Assert
+      expect(screen.queryByText(/Help content/)).not.toBeInTheDocument();
+    });
+
+    it('Should render children without popover content when isDisabled true', async () => {
+      // Arrange
+      render(
+        <HelpInfo isDisabled content="Help content">
+          My text
+        </HelpInfo>
+      );
+
+      // Act
+      UserEvent.hover(screen.getByText('My text'));
+
+      // Assert
+      expect(screen.queryByText(/Help content/)).not.toBeInTheDocument();
+    });
+
+    it('Should render children without popover content when not have content', async () => {
+      // Arrange
+      render(<HelpInfo>My text</HelpInfo>);
+
+      // Act
+      UserEvent.hover(screen.getByText('My text'));
+
+      // Assert
+      expect(screen.queryByText(/Help content/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Mode click', () => {
+    it('should show help on when clicking on children', async () => {
+      // Arrange
+      render(
+        <HelpInfo mode="click" content="Help content">
+          My text
+        </HelpInfo>
+      );
+
+      // Act
+      UserEvent.click(screen.getByText('My text'));
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText(/Help content/)).toBeInTheDocument();
+      });
+    });
+
+    it('should not hide help when clicking on help content', async () => {
+      // Arrange
+      render(
+        <HelpInfo mode="click" content="Help content">
+          My text
+        </HelpInfo>
+      );
+      UserEvent.click(screen.getByText('My text'));
+
+      await waitFor(() => {
+        screen.queryByText(/Help content/);
+      });
+
+      // Act
+      UserEvent.click(screen.getByText(/Help content/));
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.getByText(/Help content/)).toBeInTheDocument();
+      });
+    });
+
+    it('should hide help when clicking on i', async () => {
+      // Arrange
+      render(
+        <HelpInfo mode="click" content="Help content">
+          My text
+        </HelpInfo>
+      );
+
+      UserEvent.click(screen.getByText('My text'));
+
+      await waitFor(() => {
+        screen.queryByText(/Help content/);
+      });
+
+      // Act
+      UserEvent.click(screen.getByText('My text'));
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.queryByText(/Help content/)).not.toBeInTheDocument();
+      });
+    });
+
+    it('should not show help on hover', async () => {
+      // Arrange
+      render(
+        <HelpInfo mode="click" content="Help content">
+          My text
+        </HelpInfo>
+      );
+
+      // Act
+      UserEvent.hover(screen.getByText('My text'));
+
+      // Assert
+      await waitFor(() => {
+        expect(screen.queryByText(/Help content/)).not.toBeInTheDocument();
+      });
+    });
+
+    it('should not show help before click', async () => {
+      // Arrange
+      render(
+        <HelpInfo mode="click" content="Help content">
+          My text
+        </HelpInfo>
+      );
+
+      // Act
+      // No user interaction
+
+      // Assert
+      expect(screen.queryByText(/Help content/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/helpinfo/src/help-info.scss
+++ b/packages/helpinfo/src/help-info.scss
@@ -1,0 +1,14 @@
+@import '@axa-fr/react-toolkit-core/src/common/scss/core.scss';
+
+.af-popover__wrapper:has(.af-popover__container--short) {
+  position: relative;
+  display: block;
+}
+
+.af-popover__container--short {
+  display: block;
+  .af-popover__container-pop {
+    word-break: break-word;
+    width: 200px;
+  }
+}

--- a/packages/helpinfo/src/index.ts
+++ b/packages/helpinfo/src/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HelpInfo';

--- a/packages/helpinfo/tsconfig-cjs.json
+++ b/packages/helpinfo/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig-cjs.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs"
+  },
+  "include": ["./src/index.ts"]
+}

--- a/packages/helpinfo/tsconfig.json
+++ b/packages/helpinfo/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm"
+  },
+  "include": ["./src/index.ts"]
+}


### PR DESCRIPTION
## Related issue

### Reference to the issue

fix #1010 


### Description of the issue

- Create a new categorie for high level components
- Add a wrapper infobulle component (based on @axa-fr/react-toolkit-popover like Help component)
this component could wrap any component

![Capture d’écran 2023-02-10 à 16 20 03](https://user-images.githubusercontent.com/16844565/218129054-86c3a408-c126-4b5b-bab5-61b95d391224.png)


### Person(s) for reviewing proposed changes

`You can add @mention here`

# Important

Before creating a pull request run unit tests

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```
