### PR TITLE
fix(table): stories, items and mobile style

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -43,7 +43,7 @@ module.exports = {
     '../packages/popover/src/*.stories.@(ts|tsx|js)',
     '../packages/restitution/src/*.stories.@(ts|tsx|js)',
     '../packages/status/src/*.stories.@(ts|tsx|js)',
-    '../packages/table/src/*.stories.@(ts|tsx|js)',
+    '../packages/table/src/**/*.stories.@(ts|tsx|js)',
     '../packages/tabs/src/*.stories.@(ts|tsx|js)',
     '../packages/title/src/*.stories.@(ts|tsx|js)',
   ],

--- a/packages/table/src/Header.tsx
+++ b/packages/table/src/Header.tsx
@@ -14,7 +14,7 @@ const Header = ({
   const componentClassName = getComponentClassName(
     className,
     classModifier,
-    'af-table-thead'
+    'af-table__thead'
   );
   return (
     <thead className={componentClassName} {...otherProps}>

--- a/packages/table/src/Items/Items.stories.tsx
+++ b/packages/table/src/Items/Items.stories.tsx
@@ -4,7 +4,7 @@ import Items, { Props } from './Items';
 import readme from './README.md';
 
 export default {
-  title: 'Table/Items',
+  title: 'Components/Table/Items',
   component: Items,
   parameters: {
     readme: {

--- a/packages/table/src/Pager/Pager.stories.tsx
+++ b/packages/table/src/Pager/Pager.stories.tsx
@@ -5,7 +5,7 @@ import Modes from './Modes';
 import Readme from './README.md';
 
 export default {
-  title: 'Components/Pager',
+  title: 'Components/Table/Pager',
   component: Pager,
   parameters: {
     readme: {

--- a/packages/table/src/Pager/pager.scss
+++ b/packages/table/src/Pager/pager.scss
@@ -12,7 +12,7 @@
   }
 
   &__item {
-    border-radius: 100%;
+    border-radius: rem(25px);
     font-size: 0.9375rem;
 
     &--active {
@@ -48,6 +48,26 @@
       &:hover {
         text-decoration: none;
       }
+    }
+  }
+}
+
+@include media-breakpoint-down(xs) {
+  .af-paging__pager {
+    margin-top: 2rem;
+  }
+  .af-paging__limit {
+    margin: 1rem auto;
+    text-align: center;
+    width: 100%;
+    [class^='col'] {
+      padding: inherit;
+      flex-basis: inherit;
+      flex-grow: inherit;
+      width: inherit;
+    }
+    .af-form__group {
+      justify-content: space-evenly;
     }
   }
 }

--- a/packages/table/src/Paging/Paging.stories.tsx
+++ b/packages/table/src/Paging/Paging.stories.tsx
@@ -5,7 +5,7 @@ import Modes from '../Pager/Modes';
 import Readme from './README.md';
 
 export default {
-  title: 'Components/Paging',
+  title: 'Components/Table/Paging',
   component: Paging,
   parameters: {
     readme: {
@@ -45,4 +45,5 @@ Default.args = {
   currentPage: 5,
   numberPages: 23,
   numberItems: 25,
+  items: [5, 10, 25, 50, 100],
 };

--- a/packages/table/src/Paging/Paging.tsx
+++ b/packages/table/src/Paging/Paging.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentPropsWithoutRef } from 'react';
+import React, { ComponentPropsWithoutRef, useCallback } from 'react';
 import { getComponentClassName } from '@axa-fr/react-toolkit-core';
 import Pager from '../Pager/Pager';
 import Items from '../Items/Items';
@@ -23,6 +23,7 @@ const Paging = ({
   numberPages,
   ofLabel,
   previousLabel,
+  items,
   onChange,
 }: Props) => {
   const componentClassName = getComponentClassName(
@@ -30,30 +31,40 @@ const Paging = ({
     classModifier,
     'af-paging'
   );
+
+  const handleChangeItems = useCallback(
+    (e) =>
+      onChange({
+        numberItems: e.value,
+        page: currentPage,
+      }),
+    []
+  );
+
+  const handleChangePager = useCallback(
+    (e) =>
+      onChange({
+        numberItems,
+        page: e.value,
+      }),
+    []
+  );
+
   return (
     <div className={componentClassName}>
       <div className="af-paging__limit">
         <Items
-          onChange={(e) =>
-            onChange({
-              numberItems: e.value,
-              page: currentPage,
-            })
-          }
+          onChange={handleChangeItems}
           numberItems={numberItems}
           id={id}
           displayLabel={displayLabel}
           elementsLabel={elementsLabel}
+          items={items}
         />
       </div>
       <div className="af-paging__pager">
         <Pager
-          onChange={(e) =>
-            onChange({
-              numberItems,
-              page: e.value,
-            })
-          }
+          onChange={handleChangePager}
           currentPage={currentPage}
           numberPages={numberPages}
           previousLabel={previousLabel}

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -1,6 +1,5 @@
 @import '@axa-fr/react-toolkit-core/src/common/scss/core.scss';
 
-/* Legacy old version */
 .af-table {
   border-collapse: collapse;
   border-spacing: 0;
@@ -11,12 +10,6 @@
 
   &-th {
     font-weight: $table-head-font-weight;
-  }
-  @include generate-universes() {
-    .af-table-thead {
-      background-color: $color;
-      color: $table-inverse-color;
-    }
   }
 
   &__th {
@@ -29,6 +22,9 @@
     position: relative;
     padding: 1rem;
     font-weight: $table-head-font-weight;
+    &--sortable {
+      padding: 0;
+    }
 
     .af-link {
       color: $white;
@@ -44,10 +40,6 @@
       top: 50%;
       right: 1rem;
       transform: translate(0, -50%);
-    }
-
-    &--sortable {
-      padding: 0;
     }
   }
 
@@ -74,8 +66,12 @@
       border-right: 0;
     }
   }
+
+  /* Legacy old version */
   @include generate-universes() {
-    .af-table-thead {
+    .af-table__thead {
+      background-color: $color;
+      color: $table-inverse-color;
       .af-table__tr {
         .af-table__th {
           background-color: $color;
@@ -83,5 +79,46 @@
         }
       }
     }
+  }
+}
+
+/* CUSTOM mixin : shadow scroll horizontal & vertical *************************************************/
+
+@mixin scroll-horizontal-shadow($maxWidth: 100%) {
+  max-width: $maxWidth;
+  overflow: auto;
+  background: linear-gradient(
+        90deg,
+        rgba(255, 255, 245, 0.6) 30%,
+        rgba(255, 255, 255, 0)
+      )
+      left center,
+    linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 245, 0.6) 80%)
+      right center,
+    radial-gradient(
+        farthest-side at 0 50%,
+        rgba(0, 0, 0, 0.6),
+        rgba(0, 0, 0, 0)
+      )
+      0 50%,
+    radial-gradient(
+        farthest-side at 100% 50%,
+        rgba(0, 0, 0, 0.6),
+        rgba(0, 0, 0, 0)
+      )
+      right center;
+  background-repeat: no-repeat;
+  background-size: 40px 100%, 40px 100%, 14px 100%, 14px 100%;
+  background-attachment: local, local, scroll, scroll;
+}
+
+@include media-breakpoint-down(xs) {
+  .af-table__tr:nth-child(2n + 1) .af-table__cell {
+    background-color: rgba($color-gray-1, 0.5);
+  }
+  .af-table {
+    display: block;
+    margin: 0 auto;
+    @include scroll-horizontal-shadow(100%);
   }
 }


### PR DESCRIPTION
## Related issue

### Reference to the issue

fix #918 

- group stories in Table directory
<img width="216" alt="Capture d’écran 2023-03-01 à 10 43 33" src="https://user-images.githubusercontent.com/16844565/222102245-9218bce1-21ab-4c1d-8c2e-0e103fbe1105.png">

- add style for mobile

- fix border-radius for long number
![Capture d’écran 2023-03-01 à 10 45 23](https://user-images.githubusercontent.com/16844565/222102809-3837ecd6-721d-4ce4-affb-bd29f9f591b2.png)





### Person(s) for reviewing proposed changes

`You can add @mention here`

# Important

Before creating a pull request run unit tests

```sh
$ npm test

# watch for changes
$ npm test -- --watch

# For a specific file (e.g., in packages/context/__tests__/command.test.js)
$ npm test -- --watch packages/action
```
